### PR TITLE
outputs count should not be greater than inputs outpoint index

### DIFF
--- a/blockchain/txvalidator.go
+++ b/blockchain/txvalidator.go
@@ -178,6 +178,10 @@ func CheckTransactionInput(txn *Transaction) error {
 }
 
 func CheckTransactionOutput(version uint32, txn *Transaction) error {
+	if len(txn.Outputs) > math.MaxUint16 {
+		return errors.New("output count should not be greater than 65535(MaxUint16)")
+	}
+
 	if txn.IsCoinBaseTx() {
 		if len(txn.Outputs) < 2 {
 			return errors.New("coinbase output is not enough, at least 2")


### PR DESCRIPTION
In mainchain, Transaction.Input.OutPoint.Index's type is uint16. That means, if a transaction has more than 65535( max of uint16) outputs, then outputs whose index is greater than 65535 will be unavailable.It cannot be referred. So there should be a restriction, that the count of the outputs should not be greater than 65535. 