### PR TITLE
change the position of check-reward-amount-per-block feature

### DIFF
--- a/blockchain/chainstore.go
+++ b/blockchain/chainstore.go
@@ -351,16 +351,12 @@ func (c *ChainStore) PersistAsset(assetId Uint256, asset Asset) error {
 }
 
 func (c *ChainStore) GetAsset(hash Uint256) (*Asset, error) {
-	log.Debugf("GetAsset Hash: %s", hash.String())
-
 	asset := new(Asset)
 	prefix := []byte{byte(ST_Info)}
 	data, err := c.Get(append(prefix, hash.Bytes()...))
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("GetAsset Data: %s", data)
-
 	err = asset.Deserialize(bytes.NewReader(data))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
To calculate RewardAmountPerBlock, we need totalTxFee; To calculate totalTxFee, we need Inputs values; To get Inputs values, we need get the reference of those inputs. If we calculate reward in CheckTransactionSanity method, and there is accidentally a fork, then the reward of the fork chain may    not be able to be calculated, because the outputs it referred in its inputs are in orphan pool, not the ledger, and they can't be found.  So we need to move this code to the place nearby the CheckTransactionContext function, where the block is validated after being reorganized.