### PR TITLE
CheckTransactionInput performance optimization

### DIFF
--- a/blockchain/txvalidator.go
+++ b/blockchain/txvalidator.go
@@ -163,14 +163,15 @@ func CheckTransactionInput(txn *Transaction) error {
 	if len(txn.Inputs) <= 0 {
 		return errors.New("transaction has no inputs")
 	}
-	for i, utxoin := range txn.Inputs {
-		if utxoin.Previous.TxID.IsEqual(EmptyHash) && (utxoin.Previous.Index == math.MaxUint16) {
+	inputSet := make(map[string]bool)
+	for _, input := range txn.Inputs {
+		if input.Previous.TxID.IsEqual(EmptyHash) && (input.Previous.Index == math.MaxUint16) {
 			return errors.New("invalid transaction input")
 		}
-		for j := 0; j < i; j++ {
-			if utxoin.Previous.IsEqual(txn.Inputs[j].Previous) {
-				return errors.New("duplicated transaction inputs")
-			}
+		if _, ok := inputSet[input.ReferKey()]; ok {
+			return errors.New("duplicated transaction inputs")
+		} else {
+			inputSet[input.ReferKey()] = true
 		}
 	}
 

--- a/blockchain/txvalidator.go
+++ b/blockchain/txvalidator.go
@@ -163,7 +163,7 @@ func CheckTransactionInput(txn *Transaction) error {
 	if len(txn.Inputs) <= 0 {
 		return errors.New("transaction has no inputs")
 	}
-	inputSet := make(map[string]bool)
+	inputSet := make(map[string]struct{})
 	for _, input := range txn.Inputs {
 		if input.Previous.TxID.IsEqual(EmptyHash) && (input.Previous.Index == math.MaxUint16) {
 			return errors.New("invalid transaction input")
@@ -171,7 +171,7 @@ func CheckTransactionInput(txn *Transaction) error {
 		if _, ok := inputSet[input.ReferKey()]; ok {
 			return errors.New("duplicated transaction inputs")
 		} else {
-			inputSet[input.ReferKey()] = true
+			inputSet[input.ReferKey()] = struct{}{}
 		}
 	}
 

--- a/blockchain/txvalidator.go
+++ b/blockchain/txvalidator.go
@@ -163,15 +163,15 @@ func CheckTransactionInput(txn *Transaction) error {
 	if len(txn.Inputs) <= 0 {
 		return errors.New("transaction has no inputs")
 	}
-	inputSet := make(map[string]struct{})
+	existingTxInputs := make(map[string]struct{})
 	for _, input := range txn.Inputs {
 		if input.Previous.TxID.IsEqual(EmptyHash) && (input.Previous.Index == math.MaxUint16) {
 			return errors.New("invalid transaction input")
 		}
-		if _, ok := inputSet[input.ReferKey()]; ok {
+		if _, exists := existingTxInputs[input.ReferKey()]; exists {
 			return errors.New("duplicated transaction inputs")
 		} else {
-			inputSet[input.ReferKey()] = struct{}{}
+			existingTxInputs[input.ReferKey()] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
Change a nested loop to a hash map in check transaction input duplicate method. Realize performance optimization.