### PR TITLE
refactor node connecting list, make sure address remove from connecting list after dial

### DIFF
--- a/node/handlerbase.go
+++ b/node/handlerbase.go
@@ -3,7 +3,6 @@ package node
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	chain "github.com/elastos/Elastos.ELA/blockchain"
@@ -172,11 +171,8 @@ func (h *HandlerBase) onVerAck(verAck *msg.VerAck) error {
 	if LocalNode.NeedMoreAddresses() {
 		node.RequireNeighbourList()
 	}
-	addr := node.Addr()
-	port := node.Port()
-	nodeAddr := addr + ":" + strconv.Itoa(int(port))
+
 	LocalNode.RemoveFromHandshakeQueue(node)
-	LocalNode.RemoveFromConnectingList(nodeAddr)
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -78,6 +78,10 @@ type ConnectingNodes struct {
 	ConnectingAddrs map[string]struct{}
 }
 
+func (cn *ConnectingNodes) init() {
+	cn.ConnectingAddrs = make(map[string]struct{})
+}
+
 func NewNode(magic uint32, conn net.Conn) *node {
 	node := new(node)
 	node.conn = conn
@@ -103,6 +107,7 @@ func InitLocalNode() protocol.Noder {
 
 	log.Info(fmt.Sprintf("Init node ID to 0x%x", LocalNode.id))
 	LocalNode.neighbourNodes.init()
+	LocalNode.ConnectingNodes.init()
 	LocalNode.KnownAddressList.init()
 	LocalNode.TxPool.Init()
 	LocalNode.eventQueue.init()


### PR DESCRIPTION
If a node address dial succeed but do not finish handshake sequence, it will be left in node connecting list. That makes reconnecting to this node address not working because this address is "connecting".
Refactor connect() method to make sure a dialed node address will be removed from connecting list, wether handshake sequence succeed or not.