### PR TITLE
extract get tx reference method to improve block validation perfomance

### DIFF
--- a/blockchain/txpool.go
+++ b/blockchain/txpool.go
@@ -51,7 +51,6 @@ func (pool *TxPool) AppendToTxnPool(txn *Transaction) ErrCode {
 		log.Warn("[TxPool CheckTransactionContext] failed", txn.Hash().String())
 		return errCode
 	}
-
 	//verify transaction by pool with lock
 	if errCode := pool.verifyTransactionWithTxnPool(txn); errCode != Success {
 		log.Warn("[TxPool verifyTransactionWithTxnPool] failed", txn.Hash())

--- a/blockchain/txvalidator.go
+++ b/blockchain/txvalidator.go
@@ -211,23 +211,22 @@ func CheckTransactionOutput(version uint32, txn *Transaction) error {
 	if len(txn.Outputs) < 1 {
 		return errors.New("transaction has no outputs")
 	}
-
 	// check if output address is valid
-	if version&CheckTxOut == CheckTxOut {
-		for _, output := range txn.Outputs {
-			if output.AssetID != DefaultLedger.Blockchain.AssetID {
-				return errors.New("asset ID in output is invalid")
-			}
+	for _, output := range txn.Outputs {
+		if output.AssetID != DefaultLedger.Blockchain.AssetID {
+			return errors.New("asset ID in output is invalid")
+		}
 
+		// output value must >= 0
+		if output.Value < Fixed64(0) {
+			return errors.New("Invalide transaction UTXO output.")
+		}
+		if version&CheckTxOut == CheckTxOut {
 			if !CheckOutputProgramHash(output.ProgramHash) {
 				return errors.New("output address is invalid")
 			}
-			// output value must >= 0
-			if output.Value < Fixed64(0) {
-				return errors.New("Invalide transaction UTXO output.")
-			}
-
 		}
+
 	}
 
 	return nil

--- a/blockchain/validation.go
+++ b/blockchain/validation.go
@@ -14,22 +14,6 @@ import (
 	"github.com/elastos/Elastos.ELA.Utility/crypto"
 )
 
-func VerifySignature(tx *Transaction) error {
-	hashes, err := GetTxProgramHashes(tx)
-	if err != nil {
-		return err
-	}
-
-	buf := new(bytes.Buffer)
-	tx.SerializeUnsigned(buf)
-
-	// Sort first
-	common.SortProgramHashes(hashes)
-	SortPrograms(tx.Programs)
-
-	return RunPrograms(buf.Bytes(), hashes, tx.Programs)
-}
-
 func RunPrograms(data []byte, hashes []common.Uint168, programs []*Program) error {
 	if len(hashes) != len(programs) {
 		return errors.New("The number of data hashes is different with number of programs.")
@@ -73,17 +57,13 @@ func RunPrograms(data []byte, hashes []common.Uint168, programs []*Program) erro
 	return nil
 }
 
-func GetTxProgramHashes(tx *Transaction) ([]common.Uint168, error) {
+func GetTxProgramHashes(tx *Transaction, references map[*Input]*Output) ([]common.Uint168, error) {
 	if tx == nil {
 		return nil, errors.New("[Transaction],GetProgramHashes transaction is nil.")
 	}
 	hashes := make([]common.Uint168, 0)
 	uniqueHashes := make([]common.Uint168, 0)
 	// add inputUTXO's transaction
-	references, err := DefaultLedger.Store.GetTxReference(tx)
-	if err != nil {
-		return nil, errors.New("[Transaction], GetProgramHashes failed.")
-	}
 	for _, output := range references {
 		programHash := output.ProgramHash
 		hashes = append(hashes, programHash)


### PR DESCRIPTION
1. GetTxReference method visits leveldb. It introduces a performance bottleneck here. So GetTxReference method should be called as less times as possible.
2. Move check output value feature from CheckTransactionBalance method to CheckTransactionOutput method.
3. Extract a new method: CheckCoinbaseOutputLock .