### PR TITLE
fix bug that old node cannot sync blocks.

### DIFF
--- a/core/ledger/block.go
+++ b/core/ledger/block.go
@@ -1,23 +1,23 @@
 package ledger
 
 import (
-	"io"
-	"time"
 	"bytes"
-	"errors"
-	"math/rand"
 	"encoding/binary"
+	"errors"
+	"io"
+	"math/rand"
+	"time"
 
-	"Elastos.ELA/crypto"
 	. "Elastos.ELA/common"
-	"Elastos.ELA/core/asset"
-	"Elastos.ELA/common/log"
 	"Elastos.ELA/common/config"
+	"Elastos.ELA/common/log"
+	"Elastos.ELA/common/serialization"
+	"Elastos.ELA/core/asset"
+	"Elastos.ELA/core/contract/program"
 	"Elastos.ELA/core/signature"
 	tx "Elastos.ELA/core/transaction"
-	"Elastos.ELA/common/serialization"
-	"Elastos.ELA/core/contract/program"
 	"Elastos.ELA/core/transaction/payload"
+	"Elastos.ELA/crypto"
 )
 
 const (
@@ -66,7 +66,10 @@ func (b *Block) Deserialize(r io.Reader) error {
 	var tharray []Uint256
 	for i = 0; i < Len; i++ {
 		transaction := new(tx.Transaction)
-		transaction.Deserialize(r)
+		err := transaction.Deserialize(r)
+		if err != nil {
+			return errors.New("transaction deserialize error:" + err.Error())
+		}
 		txhash = transaction.Hash()
 		b.Transactions = append(b.Transactions, transaction)
 		tharray = append(tharray, txhash)

--- a/core/transaction/txAttribute.go
+++ b/core/transaction/txAttribute.go
@@ -11,13 +11,16 @@ type TransactionAttributeUsage byte
 const (
 	Nonce          TransactionAttributeUsage = 0x00
 	Script         TransactionAttributeUsage = 0x20
-	DescriptionUrl TransactionAttributeUsage = 0x81
+	Memo           TransactionAttributeUsage = 0x81
 	Description    TransactionAttributeUsage = 0x90
+	DescriptionUrl TransactionAttributeUsage = 0x91
+	Confirmations  TransactionAttributeUsage = 0x92
 )
 
 func IsValidAttributeType(usage TransactionAttributeUsage) bool {
 	return usage == Nonce || usage == Script ||
-		usage == DescriptionUrl || usage == Description
+		usage == Memo || usage == Description || usage == DescriptionUrl ||
+		usage == Confirmations
 }
 
 type TxAttribute struct {
@@ -33,7 +36,7 @@ func NewTxAttribute(u TransactionAttributeUsage, d []byte) TxAttribute {
 }
 
 func (u *TxAttribute) GetSize() uint32 {
-	if u.Usage == DescriptionUrl {
+	if u.Usage == Memo {
 		return uint32(len([]byte{(byte(0xff))}) + len([]byte{(byte(0xff))}) + len(u.Data))
 	}
 	return 0


### PR DESCRIPTION
1. add new txAttribute type
2. add error handling in block serializing codes.