### PR TITLE
remove node from connecting list after handshake timeout

### DIFF
--- a/node/handlerbase.go
+++ b/node/handlerbase.go
@@ -3,7 +3,6 @@ package node
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	chain "github.com/elastos/Elastos.ELA/blockchain"
@@ -172,11 +171,9 @@ func (h *HandlerBase) onVerAck(verAck *msg.VerAck) error {
 	if LocalNode.NeedMoreAddresses() {
 		node.RequireNeighbourList()
 	}
-	addr := node.Addr()
-	port := node.Port()
-	nodeAddr := addr + ":" + strconv.Itoa(int(port))
+
 	LocalNode.RemoveFromHandshakeQueue(node)
-	LocalNode.RemoveFromConnectingList(nodeAddr)
+	LocalNode.RemoveFromConnectingList(node.NetAddress().String())
 	return nil
 }
 

--- a/node/openconnection.go
+++ b/node/openconnection.go
@@ -49,7 +49,7 @@ func listenNodeOpenPort() {
 		node.addr, err = parseIPaddr(conn.RemoteAddr().String())
 		node.fromExtraNet = true
 		node.Read()
-		LocalNode.AddToHandshakeQueue(node)
+		LocalNode.AddToHandshakeQueue(conn.RemoteAddr().String(), node)
 	}
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -52,7 +52,7 @@ type Noder interface {
 	Height() uint64
 	GetConn() net.Conn
 	CloseConn()
-	AddToHandshakeQueue(node Noder)
+	AddToHandshakeQueue(addr string, node Noder)
 	RemoveFromHandshakeQueue(node Noder)
 	GetConnectionCount() uint
 	GetTransactionPool(bool) map[common.Uint256]*core.Transaction


### PR DESCRIPTION
If a new connection to node did not finish handshake progress, it will left in connecting list. This makes reconnection to this node will never happens again. In extreme cases, like a bad network status, all nodes can left in connecting list and makes reconnection not working any more.