### PR TITLE
fix node sync node nil pointer panic

### DIFF
--- a/node/infoupdate.go
+++ b/node/infoupdate.go
@@ -182,13 +182,7 @@ func (node *node) ConnectNodes() {
 	internal, total := node.GetConnectionCount()
 	if internal < MinConnectionCount {
 		for _, seed := range config.Parameters.SeedList {
-			// Resolve seed address first
-			addr, err := resolveAddr(seed)
-			if err != nil {
-				continue
-			}
-			log.Debugf("Seed %s, resolved addr %s", seed, addr)
-			node.Connect(addr)
+			node.Connect(seed)
 		}
 	}
 

--- a/node/infoupdate.go
+++ b/node/infoupdate.go
@@ -84,6 +84,9 @@ func (node *node) SyncBlocks() {
 		if hasSyncPeer == false {
 			LocalNode.ResetRequestedBlock()
 			syncNode = node.GetBestHeightNoder()
+			if syncNode == nil {
+				return
+			}
 			hash := chain.DefaultLedger.Store.GetCurrentBlockHash()
 			locator := chain.DefaultLedger.Blockchain.BlockLocatorFromHash(&hash)
 
@@ -108,6 +111,9 @@ func (node *node) SyncBlocks() {
 				LocalNode.SetStartHash(EmptyHash)
 				LocalNode.SetStopHash(EmptyHash)
 				syncNode := node.GetBestHeightNoder()
+				if syncNode == nil {
+					return
+				}
 				hash := chain.DefaultLedger.Store.GetCurrentBlockHash()
 				locator := chain.DefaultLedger.Blockchain.BlockLocatorFromHash(&hash)
 


### PR DESCRIPTION
The node panic issue came from node disconnection, when it has been set to sync node.
Two adjustment are in this commit.
1. Do not add a node into neighbor list before it finish handshake progress, this can prevent a non-stable node become sync node.
2. Check if sync node is a nil pointer before use it.

And the node disconnection is because of TLS certification is using the origin DNS address like node-mainnet-XXX.elastos.org. In previous commit, node connections are using resolved tcp address to prevent duplicate addresses. This works well with non TLS dial, but the TLS certification needs the origin DNS address to do verification. That makes TLS connection not working and cause node disconnection.