### PR TITLE
Fix Ctrl+C can not quit program immediately issue

### DIFF
--- a/cli/script/api/mock/node.go
+++ b/cli/script/api/mock/node.go
@@ -250,7 +250,7 @@ func (n *nodeMock) GetNeighbourAddresses() []*p2p.NetAddress {
 	panic("implement me")
 }
 
-func (n *nodeMock) WaitForSyncFinish() {
+func (n *nodeMock) WaitForSyncFinish(interrupt <-chan struct{}) {
 	panic("implement me")
 }
 

--- a/main.go
+++ b/main.go
@@ -112,21 +112,18 @@ func main() {
 	servers.ServerNode.RegisterTxPoolListener(arbitrator)
 	servers.ServerNode.RegisterTxPoolListener(chainStore)
 
-	log.Info("Start the RPC service")
+	log.Info("Start services")
 	go httpjsonrpc.StartRPCServer()
-
-	noder.WaitForSyncFinish(interrupt.C)
-
-	if interrupt.Interrupted() {
-		return
-	}
-
 	go httprestful.StartServer()
 	go httpwebsocket.StartServer()
 	if config.Parameters.HttpInfoStart {
 		go httpnodeinfo.StartServer()
 	}
 
+	noder.WaitForSyncFinish(interrupt.C)
+	if interrupt.Interrupted() {
+		return
+	}
 	log.Info("Start consensus")
 	startConsensus()
 

--- a/main.go
+++ b/main.go
@@ -115,7 +115,12 @@ func main() {
 	log.Info("Start the RPC service")
 	go httpjsonrpc.StartRPCServer()
 
-	noder.WaitForSyncFinish()
+	noder.WaitForSyncFinish(interrupt.C)
+
+	if interrupt.Interrupted() {
+		return
+	}
+
 	go httprestful.StartServer()
 	go httpwebsocket.StartServer()
 	if config.Parameters.HttpInfoStart {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -114,7 +114,7 @@ type Noder interface {
 	GetNeighborNodes() []Noder
 	GetNeighbourAddresses() []*p2p.NetAddress
 
-	WaitForSyncFinish()
+	WaitForSyncFinish(interrupt <-chan struct{})
 	CleanSubmittedTransactions(block *types.Block) error
 	MaybeAcceptTransaction(txn *types.Transaction) error
 	RemoveTransaction(txn *types.Transaction)


### PR DESCRIPTION
The WaitForSyncFinish() method will block program from quit until it finished, so quit WaitForSyncFinish() immediately if interrupt signal received.