### PR TITLE
Add filterack message to response to filterload message

### DIFF
--- a/node/handlereip001.go
+++ b/node/handlereip001.go
@@ -101,8 +101,9 @@ func (h *HandlerEIP001) HandleMessage(message p2p.Message) {
 	}
 }
 
-func (h *HandlerEIP001) onFilterLoad(msg *msg.FilterLoad) {
-	h.base.node.LoadFilter(msg)
+func (h *HandlerEIP001) onFilterLoad(filterLoad *msg.FilterLoad) {
+	h.base.node.LoadFilter(filterLoad)
+	h.base.node.SendMessage(msg.NewFilterAck())
 }
 
 func (h *HandlerEIP001) onGetBlocks(req *msg.GetBlocks) {

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -36,6 +36,7 @@ const (
 	CmdFilterAdd   = "filteradd"
 	CmdFilterClear = "filterclear"
 	CmdFilterLoad  = "filterload"
+	CmdFilterAck   = "filterack"
 	CmdMerkleBlock = "merkleblock"
 	CmdReject      = "reject"
 	CmdTxFilter    = "txfilter"

--- a/p2p/msg/filterack.go
+++ b/p2p/msg/filterack.go
@@ -1,0 +1,16 @@
+package msg
+
+import (
+	"github.com/elastos/Elastos.ELA/p2p"
+)
+
+// Ensure FilterAck implement p2p.Message interface.
+var _ p2p.Message = (*FilterAck)(nil)
+
+type FilterAck struct{ empty }
+
+func (msg *FilterAck) CMD() string {
+	return p2p.CmdFilterAck
+}
+
+func NewFilterAck() *FilterAck { return &FilterAck{} }


### PR DESCRIPTION
Some times SPV client can not receive inventory messages, it found out may be node didn't receive filterload message for some reason.  We add a new message filterack as a response to filterload message so SPV client can figure out if the filterload is received by node.  Otherwise re-send a filterload message to node if filterack message timeout.