### PR TITLE
Do not add useless addresses into AddrManager

### DIFF
--- a/p2p/addrmgr/addrmanager.go
+++ b/p2p/addrmgr/addrmanager.go
@@ -923,6 +923,25 @@ func (a *AddrManager) Good(addr *p2p.NetAddress) {
 	a.addrNew[newBucket][rmkey] = rmka
 }
 
+// SetServices sets the services for the giiven address to the provided value.
+func (a *AddrManager) SetServices(addr *p2p.NetAddress, services uint64) {
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+
+	ka := a.find(addr)
+	if ka == nil {
+		return
+	}
+
+	// Update the services if needed.
+	if ka.na.Services != services {
+		// ka.na is immutable, so replace it.
+		naCopy := *ka.na
+		naCopy.Services = services
+		ka.na = &naCopy
+	}
+}
+
 // AddLocalAddress adds na to the list of known local addresses to advertise
 // with the given priority.
 func (a *AddrManager) AddLocalAddress(na *p2p.NetAddress, priority AddressPriority) error {

--- a/p2p/msg/version.go
+++ b/p2p/msg/version.go
@@ -39,13 +39,14 @@ func (msg *Version) Deserialize(r io.Reader) error {
 		&msg.TimeStamp, &msg.Port, &msg.Nonce, &msg.Height, &msg.Relay)
 }
 
-func NewVersion(pver uint32, services, nonce, height uint64,
+func NewVersion(pver uint32, port uint16, services, nonce, height uint64,
 	disableRelayTx bool) *Version {
 
 	return &Version{
 		Version:   pver,
 		Services:  services,
 		TimeStamp: uint32(time.Now().Unix()),
+		Port:      port,
 		Nonce:     nonce,
 		Height:    height,
 		Relay:     !disableRelayTx,

--- a/p2p/nafilter.go
+++ b/p2p/nafilter.go
@@ -1,8 +1,8 @@
 package p2p
 
-// NAFilter defines a NetAddress filter interface, it is used to filter cached
-// net addresses when responding to a getaddr message.
+// NAFilter defines a NetAddress filter interface, it is used to filter inbound
+// peer addresses and cached net addresses when responding to a getaddr message.
 type NAFilter interface {
-	// Filter takes a NetAddress and return if this address is ok to respond.
+	// Filter takes a NetAddress and return if this address is ok to use.
 	Filter(na *NetAddress) bool
 }

--- a/p2p/peer/peer.go
+++ b/p2p/peer/peer.go
@@ -61,6 +61,7 @@ type MessageFunc func(peer *Peer, msg p2p.Message)
 type Config struct {
 	Magic            uint32
 	ProtocolVersion  uint32
+	DefaultPort      uint16
 	Services         uint64
 	DisableRelayTx   bool
 	HostToNetAddress HostToNetAddrFunc
@@ -854,8 +855,8 @@ func (p *Peer) localVersionMsg() (*msg.Version, error) {
 	nonce := p.cfg.GetVersionNonce()
 
 	// Version message.
-	msg := msg.NewVersion(p.cfg.ProtocolVersion, p.cfg.Services, nonce,
-		p.cfg.BestHeight(), p.cfg.DisableRelayTx)
+	msg := msg.NewVersion(p.cfg.ProtocolVersion, p.cfg.DefaultPort,
+		p.cfg.Services, nonce, p.cfg.BestHeight(), p.cfg.DisableRelayTx)
 
 	// Advertise the services flag
 	msg.Services = p.cfg.Services

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -187,6 +187,10 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, v *msg.Version) {
 
 	// Outbound connections.
 	if !sp.Inbound() {
+		// Update the address manager with the advertised services for outbound
+		// connections in case they have changed.
+		addrManager.SetServices(sp.NA(), v.Services)
+
 		// Get address that best matches.
 		lna := addrManager.GetBestLocalAddress(sp.NA())
 		if addrmgr.IsRoutable(lna) {
@@ -202,6 +206,18 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, v *msg.Version) {
 
 		// Mark the address as a known good address.
 		addrManager.Good(sp.NA())
+
+	} else { // Inbound connections.
+
+		// Create net address according to the version message.
+		na := p2p.NewNetAddressIPPort(sp.NA().IP, v.Port, v.Services)
+		log.Debugf("New inbound sp.NA %s, port %d, services %d, na %s",
+			sp.NA(), v.Port, v.Services, na)
+
+		// Filter and add valid net address to address manager.
+		if sp.NAFilter() != nil && sp.NAFilter().Filter(na) {
+			addrManager.AddAddress(na, na)
+		}
 	}
 
 	// Add valid peer to the server.
@@ -645,6 +661,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 	cfg := &peer.Config{
 		Magic:            sp.server.cfg.MagicNumber,
 		ProtocolVersion:  sp.server.cfg.ProtocolVersion,
+		DefaultPort:      sp.server.cfg.DefaultPort,
 		Services:         sp.server.cfg.Services,
 		DisableRelayTx:   sp.server.cfg.DisableRelayTx,
 		HostToNetAddress: sp.server.addrManager.HostToNetAddress,
@@ -687,7 +704,6 @@ func (s *server) inboundPeerConnected(conn net.Conn) {
 	sp.Peer = peer.NewInboundPeer(newPeerConfig(sp))
 	go s.peerDoneHandler(sp)
 	sp.AssociateConnection(conn)
-	s.addrManager.AddAddress(sp.NA(), sp.NA())
 }
 
 // outboundPeerConnected is invoked by the connection manager when a new


### PR DESCRIPTION
Now there are many useless addresses have been added into AddrManager and been relayed to other peers.  These useless addresses are added when inbound peer connected.  So we didn't add the inbound peer net address into AddrManager on connection, instead we create the net address by the version message the inbound peer send us.