### PR TITLE
Rename SFOpenNode to SFNodeBloom

### DIFF
--- a/elanet/pact/protocol.go
+++ b/elanet/pact/protocol.go
@@ -29,16 +29,15 @@ const (
 	// filtering.
 	SFTxFiltering
 
-	// SFNodeOpen is a flag used to indicate a peer supports open service by
-	// open port.
-	SFNodeOpen
+	// SFNodeBloom is a flag used to indicate a peer supports bloom filtering.
+	SFNodeBloom
 )
 
 // Map of service flags back to their constant names for pretty printing.
 var sfStrings = map[ServiceFlag]string{
 	SFNodeNetwork: "SFNodeNetwork",
 	SFTxFiltering: "SFTxFiltering",
-	SFNodeOpen:    "SFNodeOpen",
+	SFNodeBloom:   "SFNodeBloom",
 }
 
 // orderedSFStrings is an ordered list of service flags from highest to
@@ -46,7 +45,7 @@ var sfStrings = map[ServiceFlag]string{
 var orderedSFStrings = []ServiceFlag{
 	SFNodeNetwork,
 	SFTxFiltering,
-	SFNodeOpen,
+	SFNodeBloom,
 }
 
 // String returns the ServiceFlag in human-readable form.

--- a/elanet/server.go
+++ b/elanet/server.go
@@ -21,7 +21,7 @@ import (
 const (
 	// defaultServices describes the default services that are supported by
 	// the server.
-	defaultServices = pact.SFNodeNetwork | pact.SFTxFiltering
+	defaultServices = pact.SFNodeNetwork | pact.SFTxFiltering | pact.SFNodeBloom
 )
 
 // relayMsg packages an inventory vector along with the newly discovered
@@ -31,8 +31,7 @@ type relayMsg struct {
 	data    interface{}
 }
 
-// server provides a server for handling communications to and from
-// peers.
+// server provides a server for handling communications to and from peers.
 type server struct {
 	svr.IServer
 	syncManager  *netsync.SyncManager


### PR DESCRIPTION
After DPOS consensus up online, the SFOpenService flag will be deprecated.
Change it to SFNodeBloom to indicates the node supports bloom filtering.