### PR TITLE
Implement InstantBlock() for network parameters

### DIFF
--- a/blockchain/blockvalidator_test.go
+++ b/blockchain/blockvalidator_test.go
@@ -45,14 +45,14 @@ func TestCheckBlockSanity(t *testing.T) {
 		return
 	}
 	FoundationAddress = *foundation
-	chainStore, err := NewChainStore("Chain_UnitTest", config.MainNetParams.GenesisBlock)
+	chainStore, err := NewChainStore("Chain_UnitTest", config.DefaultParams.GenesisBlock)
 	if err != nil {
 		t.Error(err.Error())
 	}
 	defer chainStore.Close()
 
 	heightVersions := &mock.HeightVersionsMock{}
-	chain, _ := New(chainStore, &config.MainNetParams, heightVersions, state.NewState(nil, &config.MainNetParams))
+	chain, _ := New(chainStore, &config.DefaultParams, heightVersions, state.NewState(nil, &config.DefaultParams))
 	if DefaultLedger == nil {
 		DefaultLedger = &Ledger{
 			Blockchain:     chain,

--- a/blockchain/chainstore_test.go
+++ b/blockchain/chainstore_test.go
@@ -16,7 +16,7 @@ var sidechainTxHash common.Uint256
 
 func TestChainStoreInit(t *testing.T) {
 	// Get new chainstore
-	temp, err := NewChainStore("Chain_UnitTest", config.MainNetParams.GenesisBlock)
+	temp, err := NewChainStore("Chain_UnitTest", config.DefaultParams.GenesisBlock)
 	testChainStore = temp.(*ChainStore)
 	testChainStore.NewBatch()
 	if err != nil {

--- a/blockchain/interfaces/arbitrators.go
+++ b/blockchain/interfaces/arbitrators.go
@@ -16,7 +16,7 @@ type Arbitrators interface {
 	GetNextArbitrators() [][]byte
 	GetNextCandidates() [][]byte
 
-	GetCRCArbitrators() []config.CRCArbitratorParams
+	GetCRCArbitrators() []config.CRCArbiter
 	IsCRCArbitrator(pk []byte) bool
 	IsCRCArbitratorProgramHash(hash *common.Uint168) bool
 

--- a/blockchain/mock/arbitratorsmock.go
+++ b/blockchain/mock/arbitratorsmock.go
@@ -52,7 +52,7 @@ func (a *ArbitratorsMock) TryEnterEmergency(blockTime uint32) bool {
 	panic("implement me")
 }
 
-func (a *ArbitratorsMock) GetCRCArbitrators() []config.CRCArbitratorParams {
+func (a *ArbitratorsMock) GetCRCArbitrators() []config.CRCArbiter {
 	panic("implement me")
 }
 

--- a/blockchain/txvalidator_test.go
+++ b/blockchain/txvalidator_test.go
@@ -50,12 +50,12 @@ func (s *txValidatorTestSuite) SetupSuite() {
 
 	heightVersions := &mock.HeightVersionsMock{}
 	chainStore, err := NewChainStore("txValidatorTestSuite",
-		config.MainNetParams.GenesisBlock)
+		config.DefaultParams.GenesisBlock)
 	if err != nil {
 		s.Error(err)
 	}
-	s.Chain, err = New(chainStore, &config.MainNetParams,
-		heightVersions, state.NewState(&mock.ArbitratorsMock{}, &config.MainNetParams))
+	s.Chain, err = New(chainStore, &config.DefaultParams,
+		heightVersions, state.NewState(&mock.ArbitratorsMock{}, &config.DefaultParams))
 	if err != nil {
 		s.Error(err)
 	}
@@ -155,7 +155,7 @@ func (s *txValidatorTestSuite) TestCheckTransactionOutput() {
 	s.EqualError(err, "Asset ID in coinbase is invalid")
 
 	// reward to foundation in coinbase = 30% (CheckTxOut version)
-	totalReward := config.MainNetParams.RewardPerBlock
+	totalReward := config.DefaultParams.RewardPerBlock
 	fmt.Printf("Block reward amount %s", totalReward.String())
 	foundationReward := common.Fixed64(float64(totalReward) * 0.3)
 	fmt.Printf("Foundation reward amount %s", foundationReward.String())

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -44,7 +44,7 @@ func loadConfigParams() *config.ConfigParams {
 	cfg := loadConfigFile()
 
 	var chainParams config.ChainParams
-	switch strings.ToLower(cfg.PowConfiguration.ActiveNet) {
+	switch strings.ToLower(cfg.ActiveNet) {
 	case "mainnet", "main":
 		chainParams = config.MainNet
 

--- a/cmd/script/api/api.go
+++ b/cmd/script/api/api.go
@@ -151,17 +151,17 @@ func initLedger(L *lua.LState) int {
 	dlog.Init(logLevel, 0, 0)
 
 	verconf := &verconf.Config{
-		ChainParams: &config.MainNetParams,
+		ChainParams: &config.DefaultParams,
 	}
 	versions := version.NewVersions(verconf)
 	verconf.Versions = versions
-	chainStore, err := blockchain.NewChainStore("Chain_WhiteBox", config.MainNetParams.GenesisBlock)
+	chainStore, err := blockchain.NewChainStore("Chain_WhiteBox", config.DefaultParams.GenesisBlock)
 	if err != nil {
 		fmt.Printf("Init chain store error: %s \n", err.Error())
 	}
 
 	var interrupt = signal.NewInterrupt()
-	chain, err := blockchain.New(chainStore, &config.MainNetParams, versions, state.NewState(nil, &config.MainNetParams))
+	chain, err := blockchain.New(chainStore, &config.DefaultParams, versions, state.NewState(nil, &config.DefaultParams))
 	if err != nil {
 		fmt.Printf("Init block chain error: %s \n", err.Error())
 	}

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -53,11 +53,11 @@ var (
 )
 
 type PowConfiguration struct {
-	PayToAddr  string `json:"PayToAddr"`
-	AutoMining bool   `json:"AutoMining"`
-	MinerInfo  string `json:"MinerInfo"`
-	MinTxFee   int    `json:"MinTxFee"`
-	ActiveNet  string `json:"ActiveNet"`
+	PayToAddr    string `json:"PayToAddr"`
+	AutoMining   bool   `json:"AutoMining"`
+	MinerInfo    string `json:"MinerInfo"`
+	MinTxFee     int    `json:"MinTxFee"`
+	InstantBlock bool   `json:"InstantBlock"`
 }
 
 type RpcConfiguration struct {
@@ -66,12 +66,13 @@ type RpcConfiguration struct {
 	WhiteIPList []string `json:"WhiteIPList"`
 }
 
-type CRCArbitratorConfigItem struct {
+type CRCArbiterInfo struct {
 	PublicKey  string `json:"PublicKey"`
 	NetAddress string `json:"NetAddress"`
 }
 
 type Configuration struct {
+	ActiveNet            string               `json:"ActiveNet"`
 	Magic                uint32               `json:"Magic"`
 	FoundationAddress    string               `json:"FoundationAddress"`
 	Version              int                  `json:"Version"`
@@ -82,18 +83,10 @@ type Configuration struct {
 	RestKeyPath          string               `json:"RestKeyPath"`
 	HttpInfoPort         uint16               `json:"HttpInfoPort"`
 	HttpInfoStart        bool                 `json:"HttpInfoStart"`
-	OpenService          bool                 `json:"OpenService"`
 	HttpWsPort           int                  `json:"HttpWsPort"`
-	WsHeartbeatInterval  time.Duration        `json:"WsHeartbeatInterval"`
 	HttpJsonPort         int                  `json:"HttpJsonPort"`
 	NodePort             uint16               `json:"NodePort"`
-	NodeOpenPort         uint16               `json:"NodeOpenPort"`
 	PrintLevel           uint8                `json:"PrintLevel"`
-	IsTLS                bool                 `json:"IsTLS"`
-	CertPath             string               `json:"CertPath"`
-	KeyPath              string               `json:"KeyPath"`
-	CAPath               string               `json:"CAPath"`
-	MultiCoreNum         uint                 `json:"MultiCoreNum"`
 	MaxLogsSize          int64                `json:"MaxLogsSize"`
 	MaxPerLogSize        int64                `json:"MaxPerLogSize"`
 	MaxTxsInBlock        int                  `json:"MaxTransactionInBlock"`
@@ -107,26 +100,24 @@ type Configuration struct {
 }
 
 type ArbiterConfiguration struct {
-	PublicKey                string                    `json:"PublicKey"`
-	Magic                    uint32                    `json:"Magic"`
-	NodePort                 uint16                    `json:"NodePort"`
-	ProtocolVersion          uint32                    `json:"ProtocolVersion"`
-	Services                 uint64                    `json:"Services"`
-	PrintLevel               uint8                     `json:"PrintLevel"`
-	SignTolerance            uint64                    `json:"SignTolerance"`
-	MaxLogsSize              int64                     `json:"MaxLogsSize"`
-	MaxPerLogSize            int64                     `json:"MaxPerLogSize"`
-	MaxConnections           int                       `json:"MaxConnections"`
-	OriginArbiters           []string                  `json:"OriginArbiters"`
-	CRCArbiters              []CRCArbitratorConfigItem `json:"CRCArbiters"`
-	NormalArbitratorsCount   uint32                    `json:"NormalArbitratorsCount"`
-	CandidatesCount          uint32                    `json:"CandidatesCount"`
-	EmergencyDuration        uint32                    `json:"EmergencyDuration"`
-	EmergencyInactivePenalty common.Fixed64            `json:"EmergencyInactivePenalty"`
-	MaxInactiveRounds        uint32                    `json:"MaxInactiveRounds"`
-	InactivePenalty          common.Fixed64            `json:"InactivePenalty"`
-	InactiveEliminateCount   uint32                    `json:"InactiveEliminateCount"`
-	EnableEventRecord        bool                      `json:"EnableEventRecord"`
+	PublicKey                string           `json:"PublicKey"`
+	Magic                    uint32           `json:"Magic"`
+	NodePort                 uint16           `json:"NodePort"`
+	ProtocolVersion          uint32           `json:"ProtocolVersion"`
+	Services                 uint64           `json:"Services"`
+	PrintLevel               uint8            `json:"PrintLevel"`
+	SignTolerance            uint64           `json:"SignTolerance"`
+	MaxLogsSize              int64            `json:"MaxLogsSize"`
+	MaxPerLogSize            int64            `json:"MaxPerLogSize"`
+	OriginArbiters           []string         `json:"OriginArbiters"`
+	CRCArbiters              []CRCArbiterInfo `json:"CRCArbiters"`
+	NormalArbitratorsCount   uint32           `json:"NormalArbitratorsCount"`
+	CandidatesCount          uint32           `json:"CandidatesCount"`
+	EmergencyInactivePenalty common.Fixed64   `json:"EmergencyInactivePenalty"`
+	MaxInactiveRounds        uint32           `json:"MaxInactiveRounds"`
+	InactivePenalty          common.Fixed64   `json:"InactivePenalty"`
+	InactiveEliminateCount   uint32           `json:"InactiveEliminateCount"`
+	EnableEventRecord        bool             `json:"EnableEventRecord"`
 }
 
 type Seed struct {

--- a/common/config/params.go
+++ b/common/config/params.go
@@ -40,9 +40,8 @@ var (
 	}
 )
 
-// MainNetParams defines the network parameters for the main network.
-var MainNetParams = Params{
-	Name:        "mainnet",
+// DefaultParams defines the default network parameters.
+var DefaultParams = Params{
 	Magic:       2017001,
 	DefaultPort: 20338,
 
@@ -70,8 +69,8 @@ var MainNetParams = Params{
 		"02fa3e0d14e0e93ca41c3c0f008679e417cf2adb6375dd4bbbee9ed8e8db606a56",
 		"03ab3ecd1148b018d480224520917c6c3663a3631f198e3b25cf4c9c76786b7850",
 	},
-	CRCArbiters: []CRCArbitratorParams{
-	//todo add CRC arbiters
+	CRCArbiters: []CRCArbiter{
+		//todo add CRC arbiters
 	},
 	PowLimit:           powLimit,
 	PowLimitBits:       0x1f0008ff,
@@ -94,100 +93,76 @@ var MainNetParams = Params{
 	InactiveEliminateCount:   12,
 }
 
-// TestNetParams defines the network parameters for the test network.
-var TestNetParams = Params{
-	Name:        "testnet",
-	Magic:       2018001,
-	DefaultPort: 21338,
+// TestNet returns the network parameters for the test network.
+func (p *Params) TestNet() *Params {
+	copy := *p
+	copy.Magic = 2018001
+	copy.DefaultPort = 21338
 
-	SeedList: []string{
+	copy.SeedList = []string{
 		"node-testnet-001.elastos.org",
 		"node-testnet-002.elastos.org",
 		"node-testnet-003.elastos.org",
 		"node-testnet-004.elastos.org",
 		"node-testnet-005.elastos.org",
-	},
+	}
 
-	Foundation:   testNetFoundation,
-	GenesisBlock: GenesisBlock(&testNetFoundation),
-	OriginArbiters: []string{
+	copy.Foundation = testNetFoundation
+	copy.GenesisBlock = GenesisBlock(&testNetFoundation)
+	copy.OriginArbiters = []string{
 		"03e333657c788a20577c0288559bd489ee65514748d18cb1dc7560ae4ce3d45613",
 		"02dd22722c3b3a284929e4859b07e6a706595066ddd2a0b38e5837403718fb047c",
 		"03e4473b918b499e4112d281d805fc8d8ae7ac0a71ff938cba78006bf12dd90a85",
 		"03dd66833d28bac530ca80af0efbfc2ec43b4b87504a41ab4946702254e7f48961",
 		"02c8a87c076112a1b344633184673cfb0bb6bce1aca28c78986a7b1047d257a448",
-	},
-	CRCArbiters: []CRCArbitratorParams{
-	//todo add CRC arbiters
-	},
-	PowLimit:           powLimit,
-	PowLimitBits:       0x1f0008ff,
-	TargetTimespan:     24 * time.Hour,  // 24 hours
-	TargetTimePerBlock: 2 * time.Minute, // 2 minute
-	AdjustmentFactor:   4,               // 25% less, 400% more
-	RewardPerBlock:     rewardPerBlock(2 * time.Minute),
-	CoinbaseMaturity:   100,
-	MinTransactionFee:  100,
-	HeightVersions: []uint32{
+	}
+	copy.HeightVersions = []uint32{
 		0,
 		0,
 		1008812, //fixme edit height later
 		1108812, //fixme edit height later
-	},
-	VoteStartHeight:          1008812, //fixme edit height later
-	MaxInactiveRounds:        3,
-	InactivePenalty:          100 * 100000000,
-	EmergencyInactivePenalty: 500 * 100000000,
-	InactiveEliminateCount:   12,
+	}
+	return &copy
 }
 
-// RegNetParams defines the network parameters for the regression test network.
-var RegNetParams = Params{
-	Name:         "regnet",
-	Foundation:   testNetFoundation,
-	GenesisBlock: GenesisBlock(&testNetFoundation),
-	OriginArbiters: []string{
+// RegNet returns the network parameters for the test network.
+func (p *Params) RegNet() *Params {
+	copy := *p
+	copy.Foundation = testNetFoundation
+	copy.GenesisBlock = GenesisBlock(&testNetFoundation)
+	copy.OriginArbiters = []string{
 		"03e333657c788a20577c0288559bd489ee65514748d18cb1dc7560ae4ce3d45613",
 		"02dd22722c3b3a284929e4859b07e6a706595066ddd2a0b38e5837403718fb047c",
 		"03e4473b918b499e4112d281d805fc8d8ae7ac0a71ff938cba78006bf12dd90a85",
 		"03dd66833d28bac530ca80af0efbfc2ec43b4b87504a41ab4946702254e7f48961",
 		"02c8a87c076112a1b344633184673cfb0bb6bce1aca28c78986a7b1047d257a448",
-	},
-	CRCArbiters: []CRCArbitratorParams{
-	//todo add CRC arbiters
-	},
-
-	PowLimit:           powLimit,
-	PowLimitBits:       0x207fffff,
-	TargetTimePerBlock: 1 * time.Second,  // 1 second
-	TargetTimespan:     10 * time.Second, // 10 seconds
-	AdjustmentFactor:   4,                // 25% less, 400% more
-	RewardPerBlock:     rewardPerBlock(1 * time.Second),
-	CoinbaseMaturity:   100,
-	MinTransactionFee:  100,
-	HeightVersions: []uint32{
+	}
+	copy.HeightVersions = []uint32{
 		0,
 		0,
 		1008812, //fixme edit height later
 		1108812, //fixme edit height later
-	},
-	VoteStartHeight:          1008812, //fixme edit height later
-	MaxInactiveRounds:        3,
-	InactivePenalty:          100 * 100000000,
-	EmergencyInactivePenalty: 500 * 100000000,
-	InactiveEliminateCount:   12,
+	}
+	return &copy
+}
+
+// InstantBlock returns the network parameters for generate instant block.
+func (p *Params) InstantBlock() *Params {
+	copy := *p
+	copy.PowLimitBits = 0x207fffff
+	copy.TargetTimespan = 10 * time.Second
+	copy.TargetTimePerBlock = 1 * time.Second
+	copy.RewardPerBlock = rewardPerBlock(1 * time.Second)
+	return &copy
 }
 
 // CRCArbitratorParam defines parameters about arbitrators consensus and direct connection
-type CRCArbitratorParams struct {
+type CRCArbiter struct {
 	PublicKey  []byte
 	NetAddress string
 }
 
 type Params struct {
-	// Name defines a human-readable identifier for the network.
-	Name string
-
 	// Magic defines the magic number of the peer-to-peer network.
 	Magic uint32
 
@@ -211,7 +186,7 @@ type Params struct {
 	OriginArbiters []string
 
 	// CRCArbiters defines the fixed CRC arbiters producing the block.
-	CRCArbiters []CRCArbitratorParams
+	CRCArbiters []CRCArbiter
 
 	// PowLimit defines the highest allowed proof of work value for a block
 	// as a uint256.

--- a/common/config/template.go
+++ b/common/config/template.go
@@ -1,7 +1,5 @@
 package config
 
-import "time"
-
 var Template = Configuration{
 	Magic:               7630401,
 	Version:             23,
@@ -10,19 +8,11 @@ var Template = Configuration{
 	HttpInfoStart:       true,
 	HttpRestPort:        20334,
 	HttpWsPort:          20335,
-	WsHeartbeatInterval: 60,
 	HttpJsonPort:        20336,
 	NodePort:            20338,
-	NodeOpenPort:        20866,
-	OpenService:         true,
 	PrintLevel:          0,
 	MaxLogsSize:         0,
 	MaxPerLogSize:       0,
-	IsTLS:               false,
-	CertPath:            "./sample-cert.pem",
-	KeyPath:             "./sample-cert-key.pem",
-	CAPath:              "./sample-ca.pem",
-	MultiCoreNum:        4,
 	MaxTxsInBlock:       10000,
 	MinCrossChainTxFee:  10000,
 	PowConfiguration: PowConfiguration{
@@ -30,7 +20,6 @@ var Template = Configuration{
 		AutoMining: false,
 		MinerInfo:  "ELA",
 		MinTxFee:   100,
-		ActiveNet:  "RegNet",
 	},
 	EnableArbiter: false,
 	ArbiterConfiguration: ArbiterConfiguration{
@@ -43,10 +32,8 @@ var Template = Configuration{
 		SignTolerance:            5,
 		MaxLogsSize:              0,
 		MaxPerLogSize:            0,
-		MaxConnections:           100,
 		NormalArbitratorsCount:   5,
 		CandidatesCount:          0,
-		EmergencyDuration:        uint32((time.Hour * 24 * 7) / time.Second),
 		EmergencyInactivePenalty: 500 * 100000000,
 		MaxInactiveRounds:        3,
 		InactivePenalty:          100 * 100000000,

--- a/config.json.sample
+++ b/config.json.sample
@@ -9,19 +9,11 @@
     "HttpInfoStart": true,
     "HttpRestPort": 20334,
     "HttpWsPort": 20335,
-    "WsHeartbeatInterval": 60,
     "HttpJsonPort": 20336,
     "NodePort": 20338,
-    "NodeOpenPort": 20866,
-    "OpenService": true,
     "PrintLevel": 0,
     "MaxLogsSize": 0,
     "MaxPerLogSize": 0,
-    "IsTLS": false,
-    "CertPath": "./sample-cert.pem",
-    "KeyPath": "./sample-cert-key.pem",
-    "CAPath": "./sample-ca.pem",
-    "MultiCoreNum": 4,
     "MaxTransactionInBlock": 10000,
     "MinCrossChainTxFee": 10000,
     "PowConfiguration": {
@@ -29,7 +21,7 @@
       "AutoMining": true,
       "MinerInfo": "ELA",
       "MinTxFee": 100,
-      "ActiveNet": "TestNet"
+      "InstantBlock": false
     },
     "VoteHeight": 100,
     "EnableArbiter": false,

--- a/docs/config.json.md
+++ b/docs/config.json.md
@@ -33,16 +33,9 @@
     "WsHeartbeatInterval": 60,
     "HttpJsonPort": 10336,  //RPC port number
     "NodePort": 10338,      //P2P port number
-    "NodeOpenPort": 10866,  //P2P port number for open service
-    "OpenService": true,    //true to enable open service, false to disable
     "PrintLevel": 1,        //Log level. Level 0 is the highest, 6 is the lowest.
     "MaxLogsSize": 5000,    //Max total logs size in MB
     "MaxPerLogSize": 20,    //Max per log file size in MB
-    "IsTLS": false,         //TLS connection, true or false
-    "CertPath": "./sample-cert.pem",  //Certificate path
-    "KeyPath": "./sample-cert-key.pem",
-    "CAPath": "./sample-ca.pem",
-    "MultiCoreNum": 4,      //Max number of CPU cores to mine ELA
     "MaxTransactionInBlock": 10000, //Max transaction number in each block
     "MinCrossChainTxFee": 10000,    //Minimal cross-chain transaction fee
     "PowConfiguration": {           //

--- a/docs/mainnet_config.json.sample
+++ b/docs/mainnet_config.json.sample
@@ -20,17 +20,9 @@
     "HttpInfoStart": true,
     "HttpRestPort": 20334,
     "HttpWsPort": 20335,
-    "WsHeartbeatInterval": 60,
     "HttpJsonPort": 20336,
     "NodePort": 20338,
-    "NodeOpenPort": 20866,
-    "OpenService": false,
     "PrintLevel": 1,
-    "IsTLS": false,
-    "CertPath": "./cert.pem",
-    "KeyPath": "./cert-key.pem",
-    "CAPath": "./ca.pem",
-    "MultiCoreNum": 4,
     "MaxTransactionInBlock": 10000,
     "MinCrossChainTxFee": 10000,
     "PowConfiguration": {
@@ -38,7 +30,6 @@
       "AutoMining": false,
       "MinerInfo": "ELA",
       "MinTxFee": 100,
-      "ActiveNet": "MainNet"
     },
     "VoteHeight": 290000,
     "RpcConfiguration": {

--- a/docs/testnet_config.json.sample
+++ b/docs/testnet_config.json.sample
@@ -1,5 +1,6 @@
 {
   "Configuration": {
+    "ActiveNet": "TestNet"
     "Magic": 2018001,
     "Version": 23,
     "SeedList": [
@@ -11,17 +12,9 @@
     "HttpInfoStart": true,
     "HttpRestPort": 21334,
     "HttpWsPort": 21335,
-    "WsHeartbeatInterval": 60,
     "HttpJsonPort": 21336,
     "NodePort": 21338,
-    "NodeOpenPort": 21866,
-    "OpenService": false,
     "PrintLevel": 1,
-    "IsTLS": false,
-    "CertPath": "./sample-cert.pem",
-    "KeyPath": "./sample-cert-key.pem",
-    "CAPath": "./sample-ca.pem",
-    "MultiCoreNum": 4,
     "MaxTransactionInBlock": 10000,
     "MinCrossChainTxFee": 10000,
     "FoundationAddress":"8ZNizBf4KhhPjeJRGpox6rPcHE5Np6tFx3",
@@ -30,7 +23,6 @@
       "AutoMining": false,
       "MinerInfo": "ELA",
       "MinTxFee": 100,
-      "ActiveNet": "MainNet"
     },
     "VoteHeight": 200000,
     "RpcConfiguration": {

--- a/dpos/state/arbitrators.go
+++ b/dpos/state/arbitrators.go
@@ -153,7 +153,7 @@ func (a *Arbitrators) IsCRCArbitrator(pk []byte) bool {
 	return false
 }
 
-func (a *Arbitrators) GetCRCArbitrators() []config.CRCArbitratorParams {
+func (a *Arbitrators) GetCRCArbitrators() []config.CRCArbiter {
 	return a.chainParams.CRCArbiters
 }
 

--- a/dpos/state/state_test.go
+++ b/dpos/state/state_test.go
@@ -119,7 +119,7 @@ func mockIllegalBlockTx(publicKey []byte) *types.Transaction {
 }
 
 func TestState_ProcessTransaction(t *testing.T) {
-	state := NewState(&mock.ArbitratorsMock{}, &config.RegNetParams)
+	state := NewState(&mock.ArbitratorsMock{}, &config.DefaultParams)
 	config.Parameters = config.ConfigParams{
 		Configuration: &config.Configuration{
 			HeightVersions: []uint32{0, 100, 200, 300},
@@ -227,7 +227,7 @@ func TestState_ProcessTransaction(t *testing.T) {
 }
 
 func TestState_ProcessBlock(t *testing.T) {
-	state := NewState(&mock.ArbitratorsMock{}, &config.RegNetParams)
+	state := NewState(&mock.ArbitratorsMock{}, &config.DefaultParams)
 
 	// Create 100 producers info.
 	producers := make([]*payload.ProducerInfo, 100)
@@ -400,7 +400,7 @@ func TestState_ProcessBlock(t *testing.T) {
 }
 
 func TestState_ProcessIllegalBlockEvidence(t *testing.T) {
-	state := NewState(&mock.ArbitratorsMock{}, &config.RegNetParams)
+	state := NewState(&mock.ArbitratorsMock{}, &config.DefaultParams)
 
 	// Create 10 producers info.
 	producers := make([]*payload.ProducerInfo, 10)
@@ -456,7 +456,7 @@ func TestState_ProcessIllegalBlockEvidence(t *testing.T) {
 }
 
 func TestState_Rollback(t *testing.T) {
-	state := NewState(&mock.ArbitratorsMock{}, &config.RegNetParams)
+	state := NewState(&mock.ArbitratorsMock{}, &config.DefaultParams)
 
 	// Create 10 producers info.
 	producers := make([]*payload.ProducerInfo, 10)
@@ -507,7 +507,7 @@ func TestState_Rollback(t *testing.T) {
 }
 
 func TestState_GetHistory(t *testing.T) {
-	state := NewState(&mock.ArbitratorsMock{}, &config.RegNetParams)
+	state := NewState(&mock.ArbitratorsMock{}, &config.DefaultParams)
 
 	// Create 10 producers info.
 	producers := make([]*payload.ProducerInfo, 10)
@@ -653,7 +653,7 @@ func TestState_GetHistory(t *testing.T) {
 }
 
 func TestState_NicknameExists(t *testing.T) {
-	state := NewState(&mock.ArbitratorsMock{}, &config.RegNetParams)
+	state := NewState(&mock.ArbitratorsMock{}, &config.DefaultParams)
 
 	// Create 10 producers info.
 	producers := make([]*payload.ProducerInfo, 10)
@@ -718,7 +718,7 @@ func TestState_NicknameExists(t *testing.T) {
 }
 
 func TestState_ProducerExists(t *testing.T) {
-	state := NewState(&mock.ArbitratorsMock{}, &config.RegNetParams)
+	state := NewState(&mock.ArbitratorsMock{}, &config.DefaultParams)
 
 	// Create 10 producers info.
 	producers := make([]*payload.ProducerInfo, 10)
@@ -772,7 +772,7 @@ func TestState_ProducerExists(t *testing.T) {
 }
 
 func TestState_IsDPOSTransaction(t *testing.T) {
-	state := NewState(&mock.ArbitratorsMock{}, &config.RegNetParams)
+	state := NewState(&mock.ArbitratorsMock{}, &config.DefaultParams)
 
 	producer := &payload.ProducerInfo{
 		OwnerPublicKey: make([]byte, 33),
@@ -829,7 +829,7 @@ func TestState_IsDPOSTransaction(t *testing.T) {
 
 func TestState_InactiveProducer_Normal(t *testing.T) {
 	arbitrators := &mock.ArbitratorsMock{}
-	state := NewState(arbitrators, &config.RegNetParams)
+	state := NewState(arbitrators, &config.DefaultParams)
 
 	// Create 10 producers info.
 	producers := make([]*payload.ProducerInfo, 10)
@@ -875,8 +875,8 @@ func TestState_InactiveProducer_Normal(t *testing.T) {
 	currentHeight := 11
 
 	// simulate producers[0] confirming block failed for continuous three rounds
-	for round := 0; round < 3; round ++ {
-		for arIndex := 1; arIndex <= 5; arIndex ++ {
+	for round := 0; round < 3; round++ {
+		for arIndex := 1; arIndex <= 5; arIndex++ {
 			state.ProcessBlock(mockBlock(uint32(currentHeight)),
 				&payload.Confirm{
 					Proposal: payload.DPOSProposal{
@@ -903,7 +903,7 @@ func TestState_InactiveProducer_Normal(t *testing.T) {
 
 func TestState_InactiveProducer_FailNoContinuous(t *testing.T) {
 	arbitrators := &mock.ArbitratorsMock{}
-	state := NewState(arbitrators, &config.RegNetParams)
+	state := NewState(arbitrators, &config.DefaultParams)
 
 	// Create 10 producers info.
 	producers := make([]*payload.ProducerInfo, 10)
@@ -950,8 +950,8 @@ func TestState_InactiveProducer_FailNoContinuous(t *testing.T) {
 
 	// simulate producers[0] confirming block failed for total three rounds,
 	// but is not continuous
-	for round := 0; round < 4; round ++ {
-		for arIndex := 1; arIndex <= 5; arIndex ++ {
+	for round := 0; round < 4; round++ {
+		for arIndex := 1; arIndex <= 5; arIndex++ {
 
 			if round == 2 && arIndex == 5 {
 				state.ProcessBlock(mockBlock(uint32(currentHeight)),
@@ -980,7 +980,7 @@ func TestState_InactiveProducer_FailNoContinuous(t *testing.T) {
 
 func TestState_InactiveProducer_RecoverFromInactiveState(t *testing.T) {
 	arbitrators := &mock.ArbitratorsMock{}
-	state := NewState(arbitrators, &config.RegNetParams)
+	state := NewState(arbitrators, &config.DefaultParams)
 
 	// Create 10 producers info.
 	producers := make([]*payload.ProducerInfo, 10)
@@ -1026,8 +1026,8 @@ func TestState_InactiveProducer_RecoverFromInactiveState(t *testing.T) {
 	currentHeight := 11
 
 	// simulate producers[0] confirming block failed for continuous three rounds
-	for round := 0; round < 3; round ++ {
-		for arIndex := 1; arIndex <= 5; arIndex ++ {
+	for round := 0; round < 3; round++ {
+		for arIndex := 1; arIndex <= 5; arIndex++ {
 			state.ProcessBlock(mockBlock(uint32(currentHeight)),
 				&payload.Confirm{
 					Proposal: payload.DPOSProposal{

--- a/mempool/txpool_test.go
+++ b/mempool/txpool_test.go
@@ -44,7 +44,7 @@ func TestTxPoolInit(t *testing.T) {
 	}
 	blockchain.FoundationAddress = *foundation
 	chainStore, err := blockchain.NewChainStore("Chain_UnitTest",
-		config.MainNetParams.GenesisBlock)
+		config.DefaultParams.GenesisBlock)
 	if err != nil {
 		t.Fatal("open LedgerStore err:", err)
 		os.Exit(1)
@@ -69,8 +69,8 @@ func TestTxPoolInit(t *testing.T) {
 	}
 	arbitrators := mock.NewArbitratorsMock(arbitersByte, 0, 3)
 
-	chain, err := blockchain.New(chainStore, &config.MainNetParams,
-		nil, state.NewState(arbitrators, &config.MainNetParams))
+	chain, err := blockchain.New(chainStore, &config.DefaultParams,
+		nil, state.NewState(arbitrators, &config.DefaultParams))
 	//err = blockchain.Init(chainStore, mock.NewBlockHeightMock())
 	if err != nil {
 		t.Fatal(err, "BlockChain generate failed")

--- a/servers/httpwebsocket/server.go
+++ b/servers/httpwebsocket/server.go
@@ -21,6 +21,11 @@ import (
 	"github.com/pborman/uuid"
 )
 
+const (
+	// sessionTimeout is the duration of inactivity before we time out a session.
+	sessionTimeout = time.Minute
+)
+
 var instance *WebSocketServer
 
 var (
@@ -120,7 +125,7 @@ func (server *WebSocketServer) Stop() {
 }
 
 func (server *WebSocketServer) checkSessionsTimeout(done chan bool) {
-	ticker := time.NewTicker(time.Second * config.Parameters.Configuration.WsHeartbeatInterval)
+	ticker := time.NewTicker(sessionTimeout)
 	defer ticker.Stop()
 	for {
 		select {

--- a/version/blocks/blocks_test.go
+++ b/version/blocks/blocks_test.go
@@ -34,7 +34,7 @@ func TestBlockVersionInit(t *testing.T) {
 	)
 
 	chainStore, err := blockchain.NewChainStore("blockVersionTestSuite",
-		config.MainNetParams.GenesisBlock)
+		config.DefaultParams.GenesisBlock)
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func TestBlockVersionInit(t *testing.T) {
 		"03e281f89d85b3a7de177c240c4961cb5b1f2106f09daa42d15874a38bbeae85dd",
 		"0393e823c2087ed30871cbea9fa5121fa932550821e9f3b17acef0e581971efab0",
 	}
-	config.Parameters.ArbiterConfiguration.CRCArbiters = []config.CRCArbitratorConfigItem{
+	config.Parameters.ArbiterConfiguration.CRCArbiters = []config.CRCArbiterInfo{
 		{PublicKey: "023a133480176214f88848c6eaa684a54b316849df2b8570b57f3a917f19bbc77a"},
 		{PublicKey: "030a26f8b4ab0ea219eb461d1e454ce5f0bd0d289a6a64ffc0743dab7bd5be0be9"},
 		{PublicKey: "0288e79636e41edce04d4fa95d8f62fed73a76164f8631ccc42f5425f960e4a0c7"},
@@ -63,8 +63,8 @@ func TestBlockVersionInit(t *testing.T) {
 		CurrentArbitrators: arbitrators,
 	}
 
-	chain, err := blockchain.New(chainStore, &config.MainNetParams,
-		nil, state.NewState(arbitratorsMock, &config.MainNetParams))
+	chain, err := blockchain.New(chainStore, &config.DefaultParams,
+		nil, state.NewState(arbitratorsMock, &config.DefaultParams))
 	if err != nil {
 		t.Error(err)
 	}

--- a/version/blocks/blockv0_test.go
+++ b/version/blocks/blockv0_test.go
@@ -23,7 +23,7 @@ func (s *blockVersionV0TestSuite) SetupTest() {
 	config.Parameters = config.ConfigParams{Configuration: &config.Template}
 
 	s.Cfg = &verconf.Config{
-		ChainParams: &config.MainNetParams,
+		ChainParams: &config.DefaultParams,
 	}
 	s.Version = NewBlockV0(s.Cfg)
 }
@@ -32,7 +32,7 @@ func (s *blockVersionV0TestSuite) TestBlockVersionMain_GetNormalArbitratorsDesc(
 	originLedger := blockchain.DefaultLedger
 
 	arbitrators := make([][]byte, 0)
-	for _, v := range config.MainNetParams.OriginArbiters {
+	for _, v := range config.DefaultParams.OriginArbiters {
 		a, _ := common.HexStringToBytes(v)
 		arbitrators = append(arbitrators, a)
 	}
@@ -115,7 +115,7 @@ func (s *blockVersionV0TestSuite) TestBlockVersionMain_GetNextOnDutyArbitrator()
 
 	// fixme chain store removed, fix me later
 	//arbitrators := make([][]byte, 0)
-	//for _, v := range config.MainNetParams.OriginArbiters {
+	//for _, v := range config.DefaultParams.OriginArbiters {
 	//	a, _ := common.HexStringToBytes(v)
 	//	arbitrators = append(arbitrators, a)
 	//}

--- a/version/txs/txv0_test.go
+++ b/version/txs/txv0_test.go
@@ -48,7 +48,7 @@ func (s *txVersionV0TestSuite) TestCheckOutputProgramHash() {
 }
 
 func (s *txVersionV0TestSuite) TestCheckCoinbaseMinerReward() {
-	totalReward := config.MainNetParams.RewardPerBlock
+	totalReward := config.DefaultParams.RewardPerBlock
 	tx := &types.Transaction{
 		Version: types.TransactionVersion(s.Version.GetVersion()),
 		TxType:  types.CoinBase,

--- a/version/txs/txv1_test.go
+++ b/version/txs/txv1_test.go
@@ -48,7 +48,7 @@ func (s *txVersionV1TestSuite) TestCheckOutputProgramHash() {
 }
 
 func (s *txVersionV1TestSuite) TestCheckCoinbaseMinerReward() {
-	totalReward := config.MainNetParams.RewardPerBlock
+	totalReward := config.DefaultParams.RewardPerBlock
 	tx := &types.Transaction{
 		Version: types.TransactionVersion(s.Version.GetVersion()),
 		TxType:  types.CoinBase,

--- a/version/txs/txv2_test.go
+++ b/version/txs/txv2_test.go
@@ -53,7 +53,7 @@ func (s *txVersionV2TestSuite) TestCheckOutputProgramHash() {
 }
 
 func (s *txVersionV2TestSuite) TestCheckCoinbaseMinerReward() {
-	totalReward := config.MainNetParams.RewardPerBlock
+	totalReward := config.DefaultParams.RewardPerBlock
 	tx := &types.Transaction{
 		Version: types.TransactionVersion(s.Version.GetVersion()),
 		TxType:  types.CoinBase,

--- a/version/txs/txv3_test.go
+++ b/version/txs/txv3_test.go
@@ -53,7 +53,7 @@ func (s *txVersionV3TestSuite) TestCheckOutputProgramHash() {
 }
 
 func (s *txVersionV3TestSuite) TestCheckCoinbaseMinerReward() {
-	totalReward := config.MainNetParams.RewardPerBlock
+	totalReward := config.DefaultParams.RewardPerBlock
 	tx := &types.Transaction{
 		Version: types.TransactionVersion(s.Version.GetVersion()),
 		TxType:  types.CoinBase,


### PR DESCRIPTION
Changes:
1. Rename MainNetParams -> DefaultParams.
2. Implement TestNet() and RegNet() method for config/Params{} to simplify network parameters definition.
3. Implement InstantBlock() method to change network parameters into instant block mode.
4. Rename CRCArbitratorParams -> CRCArbiter.
5. Rename CRCArbitratorConfigItem -> CRCArbiterInfo
6. Remove config parameters that no longer use in DPOS.
7. Change WsHeartbeatInterval from config parameter to sessionTimeout constant.