### PR TITLE
Implement Mapping OutputPayload type

### DIFF
--- a/blockchain/txvalidator.go
+++ b/blockchain/txvalidator.go
@@ -480,6 +480,7 @@ func checkOutputPayload(txType TxType, output *Output) error {
 				return errors.New("output address should be standard")
 			}
 		case OTNone:
+		case OTMapping:
 		default:
 			return errors.New("transaction type dose not match the output payload type")
 		}

--- a/core/types/output.go
+++ b/core/types/output.go
@@ -14,10 +14,13 @@ type OutputType byte
 
 const (
 	// OTNone indicates there is no payload for this output.
-	OTNone OutputType = 0x00
+	OTNone OutputType = iota
 
 	// OTVote indicates the output payload is a vote.
-	OTVote OutputType = 0x01
+	OTVote
+
+	// OTMapping indicates the output payload is a mapping.
+	OTMapping
 )
 
 type OutputPayload interface {
@@ -126,6 +129,8 @@ func getOutputPayload(outputType OutputType) (OutputPayload, error) {
 		op = new(outputpayload.DefaultOutput)
 	case OTVote:
 		op = new(outputpayload.VoteOutput)
+	case OTMapping:
+		op = new(outputpayload.Mapping)
 	default:
 		return nil, errors.New("invalid transaction output type")
 	}

--- a/core/types/outputpayload/mapping.go
+++ b/core/types/outputpayload/mapping.go
@@ -1,0 +1,80 @@
+package outputpayload
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"github.com/elastos/Elastos.ELA/common"
+	"github.com/elastos/Elastos.ELA/crypto"
+)
+
+const (
+	// maxOwnerPublicKeySize defines the max OwnerPublicKey length of bytes.
+	maxOwnerPublicKeySize = 33 // 1(TYPE) + 32(PUBLIC_KEY)
+
+	// maxSideProducerIDSize defines the max SideProducerID length of bytes.
+	maxSideProducerIDSize = 256
+)
+
+// Mapping output payload is defined to mapping the main chain producer's owner
+// public key to a side chain producer.
+type Mapping struct {
+	// Version indicates the version of Mapping payload.
+	Version byte
+
+	// OwnerPublicKey is the owner public key of the main chain producer.
+	OwnerPublicKey []byte
+
+	// SideProducerID indicates a piece of data represent the identity of the
+	// side chain producer, whether it is a public key or address etc.
+	SideProducerID []byte
+}
+
+func (m *Mapping) Data() []byte {
+	buf := new(bytes.Buffer)
+	m.Serialize(buf)
+	return buf.Bytes()
+}
+
+func (m *Mapping) Serialize(w io.Writer) error {
+	if err := common.WriteUint8(w, m.Version); err != nil {
+		return err
+	}
+
+	if err := common.WriteVarBytes(w, m.OwnerPublicKey); err != nil {
+		return err
+	}
+
+	return common.WriteVarBytes(w, m.SideProducerID)
+}
+
+func (m *Mapping) Deserialize(r io.Reader) error {
+	var err error
+	m.Version, err = common.ReadUint8(r)
+	if err != nil {
+		return err
+	}
+
+	m.OwnerPublicKey, err = common.ReadVarBytes(r, maxOwnerPublicKeySize,
+		"OwnerPublicKey")
+	if err != nil {
+		return err
+	}
+
+	m.SideProducerID, err = common.ReadVarBytes(r, maxSideProducerIDSize,
+		"SideProducerID")
+	return err
+}
+
+func (m *Mapping) GetVersion() byte {
+	return m.Version
+}
+
+func (m *Mapping) Validate() error {
+	_, err := crypto.DecodePoint(m.OwnerPublicKey)
+	if err != nil {
+		return errors.New("mapping invalid OwnerPublicKey")
+	}
+	return nil
+}

--- a/core/types/outputpayload/mapping_test.go
+++ b/core/types/outputpayload/mapping_test.go
@@ -5,22 +5,30 @@ import (
 	"crypto/rand"
 	"testing"
 
+	"github.com/elastos/Elastos.ELA/crypto"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMapping_Serialize(t *testing.T) {
 	m := Mapping{}
-	m.OwnerPublicKey = make([]byte, 33)
+	priKey, pubKey, err := crypto.GenerateKeyPair()
+	m.OwnerPublicKey, _ = pubKey.EncodePoint(true)
 	m.SideProducerID = make([]byte, 33)
+	m.Signature, _ = crypto.Sign(priKey, m.Data())
+
 	buf := new(bytes.Buffer)
-	err := m.Serialize(buf)
+	err = m.Serialize(buf)
 	assert.NoError(t, err)
 
 	// 1 byte(Version)
 	// 1 byte(len) + 33 bytes(OwnerPublicKey)
 	// 1 byte(len) + 33 bytes(SideProducerID)
-	// = 69 bytes
-	assert.Equal(t, 69, buf.Len())
+	// 1 byte(len) + 64 bytes(Signature)
+	// = 134 bytes
+	assert.Equal(t, 134, buf.Len())
+
+	err = m.Validate()
+	assert.NoError(t, err)
 }
 
 func TestMapping_Deserialize(t *testing.T) {
@@ -46,10 +54,11 @@ func TestMapping_Deserialize(t *testing.T) {
 	// Equal test.
 	m1, m2 := Mapping{}, Mapping{}
 	m1.Version = 2
-	m1.OwnerPublicKey = make([]byte, 33)
+	priKey, pubKey, err := crypto.GenerateKeyPair()
+	m1.OwnerPublicKey, _ = pubKey.EncodePoint(true)
 	m1.SideProducerID = make([]byte, 33)
-	rand.Read(m1.OwnerPublicKey)
 	rand.Read(m1.SideProducerID)
+	m1.Signature, _ = crypto.Sign(priKey, m1.Data())
 
 	buf = new(bytes.Buffer)
 	err = m1.Serialize(buf)
@@ -59,6 +68,9 @@ func TestMapping_Deserialize(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, m1, m2)
+
+	err = m2.Validate()
+	assert.NoError(t, err)
 }
 
 func TestMapping_Validate(t *testing.T) {

--- a/core/types/outputpayload/mapping_test.go
+++ b/core/types/outputpayload/mapping_test.go
@@ -1,0 +1,70 @@
+package outputpayload
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapping_Serialize(t *testing.T) {
+	m := Mapping{}
+	m.OwnerPublicKey = make([]byte, 33)
+	m.SideProducerID = make([]byte, 33)
+	buf := new(bytes.Buffer)
+	err := m.Serialize(buf)
+	assert.NoError(t, err)
+
+	// 1 byte(Version)
+	// 1 byte(len) + 33 bytes(OwnerPublicKey)
+	// 1 byte(len) + 33 bytes(SideProducerID)
+	// = 69 bytes
+	assert.Equal(t, 69, buf.Len())
+}
+
+func TestMapping_Deserialize(t *testing.T) {
+	m := Mapping{}
+	// OwnerPublicKey over size.
+	m.OwnerPublicKey = make([]byte, 34)
+	m.SideProducerID = make([]byte, 33)
+	buf := new(bytes.Buffer)
+	err := m.Serialize(buf)
+	assert.NoError(t, err)
+	err = m.Deserialize(buf)
+	assert.Error(t, err)
+
+	// SideProducerID over size.
+	m.OwnerPublicKey = make([]byte, 33)
+	m.SideProducerID = make([]byte, 257)
+	buf = new(bytes.Buffer)
+	err = m.Serialize(buf)
+	assert.NoError(t, err)
+	err = m.Deserialize(buf)
+	assert.Error(t, err)
+
+	// Equal test.
+	m1, m2 := Mapping{}, Mapping{}
+	m1.Version = 2
+	m1.OwnerPublicKey = make([]byte, 33)
+	m1.SideProducerID = make([]byte, 33)
+	rand.Read(m1.OwnerPublicKey)
+	rand.Read(m1.SideProducerID)
+
+	buf = new(bytes.Buffer)
+	err = m1.Serialize(buf)
+	assert.NoError(t, err)
+
+	err = m2.Deserialize(buf)
+	assert.NoError(t, err)
+
+	assert.Equal(t, m1, m2)
+}
+
+func TestMapping_Validate(t *testing.T) {
+	m := Mapping{}
+	m.OwnerPublicKey = make([]byte, 33)
+	m.SideProducerID = make([]byte, 33)
+	err := m.Validate()
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Mapping output is a new output type for register main chain owner public key to a side chain producer.