### PR TITLE
Adjust median time through P2P network

### DIFF
--- a/blockchain/mediantime.go
+++ b/blockchain/mediantime.go
@@ -29,7 +29,7 @@ var (
 	// maxMedianTimeEntries is the maximum number of entries allowed in the
 	// median time data.  This is a variable as opposed to a constant so the
 	// test code can modify it.
-	maxMedianTimeEntries = 200
+	maxMedianTimeEntries = 199
 )
 
 // MedianTimeSource provides a mechanism to add several time samples which are
@@ -139,15 +139,6 @@ func (m *medianTime) AddTimeSample(sourceID string, timeVal time.Time) {
 	log.Debugf("Added time sample of %v (total: %v)", offsetDuration,
 		numOffsets)
 
-	// NOTE: The following code intentionally has a bug to mirror the
-	// buggy behavior in Bitcoin Core since the median time is used in the
-	// consensus rules.
-	//
-	// In particular, the offset is only updated when the number of entries
-	// is odd, but the max number of entries is 200, an even number.  Thus,
-	// the offset will never be updated again once the max number of entries
-	// is reached.
-
 	// The median offset is only updated when there are enough offsets and
 	// the number of offsets is odd so the middle value is the true median.
 	// Thus, there is nothing to do when those conditions are not met.
@@ -185,7 +176,7 @@ func (m *medianTime) AddTimeSample(sourceID string, timeVal time.Time) {
 			// Warn if none of the time samples are close.
 			if !remoteHasCloseTime {
 				log.Warnf("Please check your date and time " +
-					"are correct!  btcd will not work " +
+					"are correct!  ela will not work " +
 					"properly with an invalid time")
 			}
 		}

--- a/blockchain/mediantime_test.go
+++ b/blockchain/mediantime_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2013-2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"github.com/elastos/Elastos.ELA/common/log"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestMedianTime tests the medianTime implementation.
+func TestMedianTime(t *testing.T) {
+	log.NewDefault(5, 0, 0)
+
+	tests := []struct {
+		in         []int64
+		wantOffset int64
+		useDupID   bool
+	}{
+		// Not enough samples must result in an offset of 0.
+		{in: []int64{1}, wantOffset: 0},
+		{in: []int64{1, 2}, wantOffset: 0},
+		{in: []int64{1, 2, 3}, wantOffset: 0},
+		{in: []int64{1, 2, 3, 4}, wantOffset: 0},
+
+		// Various number of entries.  The expected offset is only
+		// updated on odd number of elements.
+		{in: []int64{-13, 57, -4, -23, -12}, wantOffset: -12},
+		{in: []int64{55, -13, 61, -52, 39, 55}, wantOffset: 39},
+		{in: []int64{-62, -58, -30, -62, 51, -30, 15}, wantOffset: -30},
+		{in: []int64{29, -47, 39, 54, 42, 41, 8, -33}, wantOffset: 39},
+		{in: []int64{37, 54, 9, -21, -56, -36, 5, -11, -39}, wantOffset: -11},
+		{in: []int64{57, -28, 25, -39, 9, 63, -16, 19, -60, 25}, wantOffset: 9},
+		{in: []int64{-5, -4, -3, -2, -1}, wantOffset: -3, useDupID: true},
+
+		// Offsets that are too far away from the local time should
+		// be ignored.
+		{in: []int64{-4201, 4202, -4203, 4204, -4205}, wantOffset: 0},
+
+		// Exercise the condition where the median offset is greater
+		// than the max allowed adjustment, but there is at least one
+		// sample that is close enough to the current time to avoid
+		// triggering a warning about an invalid local clock.
+		{in: []int64{4201, 4202, 4203, 4204, -299}, wantOffset: 0},
+	}
+
+	// Modify the max number of allowed median time entries for these tests.
+	maxMedianTimeEntries = 9
+	defer func() { maxMedianTimeEntries = 199 }()
+
+	for i, test := range tests {
+		filter := NewMedianTime()
+		for j, offset := range test.in {
+			id := strconv.Itoa(j)
+			now := time.Unix(time.Now().Unix(), 0)
+			tOffset := now.Add(time.Duration(offset) * time.Second)
+			filter.AddTimeSample(id, tOffset)
+
+			// Ensure the duplicate IDs are ignored.
+			if test.useDupID {
+				// Modify the offsets to ensure the final median
+				// would be different if the duplicate is added.
+				tOffset = tOffset.Add(time.Duration(offset) *
+					time.Second)
+				filter.AddTimeSample(id, tOffset)
+			}
+		}
+
+		// Since it is possible that the time.Now call in AddTimeSample
+		// and the time.Now calls here in the tests will be off by one
+		// second, allow a fudge factor to compensate.
+		gotOffset := filter.Offset()
+		wantOffset := time.Duration(test.wantOffset) * time.Second
+		wantOffset2 := time.Duration(test.wantOffset-1) * time.Second
+		if gotOffset != wantOffset && gotOffset != wantOffset2 {
+			t.Errorf("Offset #%d: unexpected offset -- got %v, "+
+				"want %v or %v", i, gotOffset, wantOffset,
+				wantOffset2)
+			continue
+		}
+
+		// Since it is possible that the time.Now call in AdjustedTime
+		// and the time.Now call here in the tests will be off by one
+		// second, allow a fudge factor to compensate.
+		adjustedTime := filter.AdjustedTime()
+		now := time.Unix(time.Now().Unix(), 0)
+		wantTime := now.Add(filter.Offset())
+		wantTime2 := now.Add(filter.Offset() - time.Second)
+		if !adjustedTime.Equal(wantTime) && !adjustedTime.Equal(wantTime2) {
+			t.Errorf("AdjustedTime #%d: unexpected result -- got %v, "+
+				"want %v or %v", i, adjustedTime, wantTime,
+				wantTime2)
+			continue
+		}
+	}
+}

--- a/elanet/peer/peer.go
+++ b/elanet/peer/peer.go
@@ -47,6 +47,9 @@ var (
 )
 
 type Listeners struct {
+	// OnVersion is invoked when a peer receives a version message.
+	OnVersion func(p *Peer, msg *msg.Version)
+
 	// OnMemPool is invoked when a peer receives a mempool message.
 	OnMemPool func(p *Peer, msg *msg.MemPool)
 
@@ -638,13 +641,7 @@ func New(orgPeer server.IPeer, listeners *Listeners) *Peer {
 		p.stallControl <- stallControlMsg{sccHandlerStart, m}
 		switch m := m.(type) {
 		case *msg.Version:
-			// Disconnect full node peers that do not support DPOS protocol.
-			if m.Relay && p.ProtocolVersion() < pact.DPOSStartVersion {
-				p.Disconnect()
-				return
-			}
-
-			p.SetDisableRelayTx(!m.Relay)
+			listeners.OnVersion(p, m)
 
 		case *msg.MemPool:
 			listeners.OnMemPool(p, m)

--- a/p2p/msg/version.go
+++ b/p2p/msg/version.go
@@ -14,7 +14,7 @@ var _ p2p.Message = (*Version)(nil)
 type Version struct {
 	Version   uint32
 	Services  uint64
-	TimeStamp uint32
+	Timestamp time.Time
 	Port      uint16
 	Nonce     uint64
 	Height    uint64
@@ -30,22 +30,29 @@ func (msg *Version) MaxLength() uint32 {
 }
 
 func (msg *Version) Serialize(w io.Writer) error {
-	return common.WriteElements(w, msg.Version, msg.Services,
-		msg.TimeStamp, msg.Port, msg.Nonce, msg.Height, msg.Relay)
+	var timestamp = uint32(msg.Timestamp.Unix())
+	return common.WriteElements(w, msg.Version, msg.Services, timestamp,
+		msg.Port, msg.Nonce, msg.Height, msg.Relay)
 }
 
 func (msg *Version) Deserialize(r io.Reader) error {
-	return common.ReadElements(r, &msg.Version, &msg.Services,
-		&msg.TimeStamp, &msg.Port, &msg.Nonce, &msg.Height, &msg.Relay)
+	var timestamp uint32
+	err := common.ReadElements(r, &msg.Version, &msg.Services, &timestamp,
+		&msg.Port, &msg.Nonce, &msg.Height, &msg.Relay)
+	if err != nil {
+		return err
+	}
+
+	msg.Timestamp = time.Unix(int64(timestamp), 0)
+	return nil
 }
 
 func NewVersion(pver uint32, port uint16, services, nonce, height uint64,
 	disableRelayTx bool) *Version {
-
 	return &Version{
 		Version:   pver,
 		Services:  services,
-		TimeStamp: uint32(time.Now().Unix()),
+		Timestamp: time.Unix(time.Now().Unix(), 0),
 		Port:      port,
 		Nonce:     nonce,
 		Height:    height,

--- a/p2p/peer/peer.go
+++ b/p2p/peer/peer.go
@@ -794,7 +794,7 @@ func (p *Peer) handleRemoteVersionMsg(msg *msg.Version) error {
 	p.statsMtx.Lock()
 	p.height = uint32(msg.Height)
 	p.startingHeight = p.height
-	p.timeOffset = int64(msg.TimeStamp) - time.Now().Unix()
+	p.timeOffset = msg.Timestamp.Unix() - time.Now().Unix()
 	p.statsMtx.Unlock()
 
 	// Negotiate the protocol version.


### PR DESCRIPTION
The median time in ELA peer-to-peer network is never adjusted.  This PR is to fix this issue, specifically append timestamp sample when receive a version message from a connected peer.