### PR TITLE
Use QueueMessage() instead of SendMessage() method

### DIFF
--- a/dpos/p2p/server.go
+++ b/dpos/p2p/server.go
@@ -298,7 +298,7 @@ func (s *server) handleBroadcastMsg(state *peerState, bmsg *broadcastMsg) {
 	})
 
 	for _, sp := range groups {
-		go sp.SendMessage(bmsg.message, nil)
+		sp.QueueMessage(bmsg.message, nil)
 	}
 }
 
@@ -392,7 +392,7 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 		done := make(chan error, 1)
 		state.forAllPeers(func(sp *serverPeer) {
 			if !sent && sp.PID().Equal(msg.pid) {
-				sp.SendMessage(msg.msg, done)
+				sp.QueueMessage(msg.msg, done)
 				if err := <-done; err == nil {
 					sent = true
 				}

--- a/elanet/dns/dns_test.go
+++ b/elanet/dns/dns_test.go
@@ -46,9 +46,6 @@ func mockInboundPeer(port int, pc chan *peer.Peer,
 		MessageFunc: func(peer *peer.Peer, m p2p.Message) {
 			switch m := m.(type) {
 			case *msg.VerAck:
-				done := make(chan struct{})
-				peer.SendMessage(&msg.GetAddr{}, done)
-				<-done
 				pc <- peer
 
 			case *msg.Addr:

--- a/p2p/peer/peer.go
+++ b/p2p/peer/peer.go
@@ -1,6 +1,7 @@
 package peer
 
 import (
+	"container/list"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,9 @@ import (
 )
 
 const (
+	// outputBufferSize is the number of elements the output channels use.
+	outputBufferSize = 50
+
 	// idleTimeout is the duration of inactivity before we time out a peer.
 	idleTimeout = 2 * time.Minute
 
@@ -26,9 +30,6 @@ const (
 	// negotiateTimeout is the duration of inactivity before we timeout a
 	// peer that hasn't completed the initial version negotiation.
 	negotiateTimeout = 30 * time.Second
-
-	// writeTimeout is the duration of write message before we time out a peer.
-	writeTimeout = 30 * time.Second
 )
 
 // outMsg is used to house a message to be sent along with a channel to signal
@@ -38,6 +39,35 @@ type outMsg struct {
 	msg      p2p.Message
 	doneChan chan<- struct{}
 }
+
+// StallControlCmd represents the command of a stall control message.
+type StallControlCmd uint8
+
+// Constants for the command of a stall control message.
+const (
+	// SCCSendMessage indicates a message is being sent to the remote peer.
+	SCCSendMessage StallControlCmd = iota
+
+	// SCCReceiveMessage indicates a message has been received from the
+	// remote peer.
+	SCCReceiveMessage
+
+	// SCCHandlerStart indicates a callback handler is about to be invoked.
+	SCCHandlerStart
+
+	// SCCHandlerDone indicates a callback handler has completed.
+	SCCHandlerDone
+)
+
+// StallControlMsg is used to signal the stall handler about specific events
+// so it can properly detect and handle stalled remote peers.
+type StallControlMsg struct {
+	CMD StallControlCmd
+	MSG p2p.Message
+}
+
+// StallHandler defines the interfaces to invoke stall control messages.
+type StallHandler func(msg StallControlMsg)
 
 // StatsSnap is a snapshot of peer stats at a point in time.
 type StatsSnap struct {
@@ -119,7 +149,6 @@ type Peer struct {
 	lastRecv   int64
 	lastSend   int64
 	connected  int32
-	started    int32
 	disconnect int32
 
 	conn net.Conn
@@ -130,6 +159,7 @@ type Peer struct {
 	cfg          Config
 	inbound      bool
 	messageFuncs []MessageFunc
+	stallHandle  StallHandler
 
 	flagsMtx           sync.Mutex // protects the peer flags below
 	na                 *p2p.NetAddress
@@ -150,9 +180,12 @@ type Peer struct {
 	lastPingTime   time.Time // Time we sent last ping.
 	lastPingMicros int64     // Time for last ping to return.
 
+	stallControl  chan StallControlMsg
+	outputQueue   chan outMsg
 	sendQueue     chan outMsg
-	sendDoneQueue chan<- struct{}
+	sendDoneQueue chan struct{}
 	inQuit        chan struct{}
+	queueQuit     chan struct{}
 	outQuit       chan struct{}
 	quit          chan struct{}
 }
@@ -169,6 +202,11 @@ func (p *Peer) handleMessage(peer *Peer, msg p2p.Message) {
 	for _, messageFunc := range p.messageFuncs {
 		messageFunc(peer, msg)
 	}
+}
+
+// SetStallHandler set the stall handler for the peer.
+func (p *Peer) SetStallHandler(handler StallHandler) {
+	p.stallHandle = handler
 }
 
 // String returns the peer's address and directionality as a human-readable
@@ -430,7 +468,7 @@ func (p *Peer) PushAddrMsg(addresses []*p2p.NetAddress) []*p2p.NetAddress {
 		addr.AddrList = addr.AddrList[:msg.MaxAddrPerMsg]
 	}
 
-	p.SendMessage(addr, nil)
+	p.QueueMessage(addr, nil)
 	return addr.AddrList
 }
 
@@ -443,7 +481,7 @@ func (p *Peer) handlePingMsg(ping *msg.Ping) {
 		p.height = newHeight
 	}
 	p.statsMtx.Unlock()
-	p.SendMessage(msg.NewPong(p.cfg.BestHeight()), nil)
+	p.QueueMessage(msg.NewPong(p.cfg.BestHeight()), nil)
 }
 
 // handlePongMsg is invoked when a peer receives a pong message.
@@ -519,18 +557,8 @@ func (p *Peer) writeMessage(msg p2p.Message) error {
 		return fmt.Sprintf("Sending %v%s to %s", msg.CMD(), summary, p)
 	}))
 
-	// Handle write message timeout.
-	doneChan := make(chan error)
-	go func() {
-		doneChan <- p2p.WriteMessage(p.conn, p.cfg.Magic, msg)
-	}()
-
-	select {
-	case err := <-doneChan:
-		return err
-	case <-time.After(writeTimeout):
-	}
-	return fmt.Errorf("sending %s to %s timeout", msg.CMD(), p)
+	// Write the message to the peer.
+	return p2p.WriteMessage(p.conn, p.cfg.Magic, msg)
 }
 
 // shouldHandleIOError returns whether or not the passed error, which is
@@ -552,6 +580,54 @@ func (p *Peer) shouldHandleIOError(err error) bool {
 	return true
 }
 
+// stallHandler handles stall detection for the peer.  This entails keeping
+// track of expected responses and assigning them deadlines while accounting for
+// the time spent in callbacks.  It must be run as a goroutine.
+func (p *Peer) stallHandler() {
+	// ioStopped is used to detect when both the input and output handler
+	// goroutines are done.
+	var ioStopped bool
+out:
+	for {
+		select {
+		case msg := <-p.stallControl:
+			// Invoke stall control message to upper layer if configured.
+			if p.stallHandle != nil {
+				p.stallHandle(msg)
+			}
+
+		case <-p.inQuit:
+			// The stall handler can exit once both the input and
+			// output handler goroutines are done.
+			if ioStopped {
+				break out
+			}
+			ioStopped = true
+
+		case <-p.outQuit:
+			// The stall handler can exit once both the input and
+			// output handler goroutines are done.
+			if ioStopped {
+				break out
+			}
+			ioStopped = true
+		}
+	}
+
+	// Drain any wait channels before going away so there is nothing left
+	// waiting on this goroutine.
+cleanup:
+	for {
+		select {
+		case <-p.stallControl:
+		default:
+			break cleanup
+		}
+	}
+}
+
+// inHandler handles all incoming messages for the peer.  It must be run as a
+// goroutine.
 func (p *Peer) inHandler() {
 	// The timer is stopped when a new message is received and reset after it
 	// is processed.
@@ -587,21 +663,23 @@ out:
 				rejectMsg := msg.NewReject("malformed", msg.RejectMalformed, errMsg)
 				// Send the message and block until it has been sent before returning.
 				doneChan := make(chan struct{}, 1)
-				p.SendMessage(rejectMsg, doneChan)
+				p.QueueMessage(rejectMsg, doneChan)
 				<-doneChan
 			}
 			break out
 		}
 		atomic.StoreInt64(&p.lastRecv, time.Now().Unix())
+		p.stallControl <- StallControlMsg{SCCReceiveMessage, rmsg}
 
 		// Handle each supported message type.
+		p.stallControl <- StallControlMsg{SCCHandlerStart, rmsg}
 		switch m := rmsg.(type) {
 		case *msg.Version:
 
 			rejectMsg := msg.NewReject(m.CMD(), msg.RejectDuplicate, "duplicate version message")
 			// Send the message and block until it has been sent before returning.
 			doneChan := make(chan struct{}, 1)
-			p.SendMessage(rejectMsg, doneChan)
+			p.QueueMessage(rejectMsg, doneChan)
 			<-doneChan
 			break out
 
@@ -622,11 +700,11 @@ out:
 
 		case *msg.Pong:
 			p.handlePongMsg(m)
-
 		}
 
 		// Call handle message which is configured on peer creation.
 		p.handleMessage(p, rmsg)
+		p.stallControl <- StallControlMsg{SCCHandlerDone, rmsg}
 
 		// A message was received so reset the idle timer.
 		idleTimer.Reset(idleTimeout)
@@ -639,6 +717,82 @@ out:
 	p.Disconnect()
 
 	close(p.inQuit)
+}
+
+// queueHandler handles the queuing of outgoing data for the peer. This runs as
+// a muxer for various sources of input so we can ensure that server and peer
+// handlers will not block on us sending a message.  That data is then passed on
+// to outHandler to be actually written.
+func (p *Peer) queueHandler() {
+	pendingMsgs := list.New()
+
+	// We keep the waiting flag so that we know if we have a message queued
+	// to the outHandler or not.  We could use the presence of a head of
+	// the list for this but then we have rather racy concerns about whether
+	// it has gotten it at cleanup time - and thus who sends on the
+	// message's done channel.  To avoid such confusion we keep a different
+	// flag and pendingMsgs only contains messages that we have not yet
+	// passed to outHandler.
+	waiting := false
+
+	// To avoid duplication below.
+	queuePacket := func(msg outMsg, list *list.List, waiting bool) bool {
+		if !waiting {
+			p.sendQueue <- msg
+		} else {
+			list.PushBack(msg)
+		}
+		// we are always waiting now.
+		return true
+	}
+out:
+	for {
+		select {
+		case msg := <-p.outputQueue:
+			waiting = queuePacket(msg, pendingMsgs, waiting)
+
+		// This channel is notified when a message has been sent across
+		// the network socket.
+		case <-p.sendDoneQueue:
+			// No longer waiting if there are no more messages
+			// in the pending messages queue.
+			next := pendingMsgs.Front()
+			if next == nil {
+				waiting = false
+				continue
+			}
+
+			// Notify the outHandler about the next item to
+			// asynchronously send.
+			val := pendingMsgs.Remove(next)
+			p.sendQueue <- val.(outMsg)
+
+		case <-p.quit:
+			break out
+		}
+	}
+
+	// Drain any wait channels before we go away so we don't leave something
+	// waiting for us.
+	for e := pendingMsgs.Front(); e != nil; e = pendingMsgs.Front() {
+		val := pendingMsgs.Remove(e)
+		msg := val.(outMsg)
+		if msg.doneChan != nil {
+			msg.doneChan <- struct{}{}
+		}
+	}
+cleanup:
+	for {
+		select {
+		case msg := <-p.outputQueue:
+			if msg.doneChan != nil {
+				msg.doneChan <- struct{}{}
+			}
+		default:
+			break cleanup
+		}
+	}
+	close(p.queueQuit)
 }
 
 // outHandler handles all outgoing messages for the peer.  It must be run as a
@@ -656,6 +810,8 @@ out:
 				p.lastPingTime = time.Now()
 				p.statsMtx.Unlock()
 			}
+
+			p.stallControl <- StallControlMsg{SCCSendMessage, smsg.msg}
 
 			err := p.writeMessage(smsg.msg)
 			if err != nil {
@@ -677,14 +833,14 @@ out:
 			if smsg.doneChan != nil {
 				smsg.doneChan <- struct{}{}
 			}
-			if p.sendDoneQueue != nil {
-				p.sendDoneQueue <- struct{}{}
-			}
+			p.sendDoneQueue <- struct{}{}
 
 		case <-p.quit:
 			break out
 		}
 	}
+
+	<-p.queueQuit
 
 	// Drain any wait channels before going away so there is nothing left
 	// waiting on this goroutine.
@@ -713,7 +869,7 @@ out:
 	for {
 		select {
 		case <-pingTicker.C:
-			p.SendMessage(msg.NewPing(p.cfg.BestHeight()), nil)
+			p.QueueMessage(msg.NewPing(p.cfg.BestHeight()), nil)
 
 		case <-p.quit:
 			break out
@@ -721,7 +877,10 @@ out:
 	}
 }
 
-func (p *Peer) SendMessage(msg p2p.Message, doneChan chan<- struct{}) {
+// QueueMessage adds the passed bitcoin message to the peer send queue.
+//
+// This function is safe for concurrent access.
+func (p *Peer) QueueMessage(msg p2p.Message, doneChan chan<- struct{}) {
 	// Avoid risk of deadlock if goroutine already exited.  The goroutine
 	// we will be sending to hangs around until it knows for a fact that
 	// it is marked as disconnected and *then* it drains the channels.
@@ -733,11 +892,7 @@ func (p *Peer) SendMessage(msg p2p.Message, doneChan chan<- struct{}) {
 		}
 		return
 	}
-	p.sendQueue <- outMsg{msg: msg, doneChan: doneChan}
-}
-
-func (p *Peer) OnSendDone(sendDoneChan chan<- struct{}) {
-	p.sendDoneQueue = sendDoneChan
+	p.outputQueue <- outMsg{msg: msg, doneChan: doneChan}
 }
 
 // Connected returns whether or not the peer is currently connected.
@@ -745,7 +900,6 @@ func (p *Peer) OnSendDone(sendDoneChan chan<- struct{}) {
 // This function is safe for concurrent access.
 func (p *Peer) Connected() bool {
 	return atomic.LoadInt32(&p.connected) != 0 &&
-		atomic.LoadInt32(&p.started) != 0 &&
 		atomic.LoadInt32(&p.disconnect) == 0
 
 }
@@ -761,23 +915,7 @@ func (p *Peer) Disconnect() {
 	if atomic.LoadInt32(&p.connected) != 0 {
 		p.conn.Close()
 	}
-	atomic.StoreInt32(&p.started, 0)
 	close(p.quit)
-}
-
-// InQuit returns the signal chan of message inHandler quit.
-func (p *Peer) InQuit() <-chan struct{} {
-	return p.inQuit
-}
-
-// OutQuit returns the signal chan of message outHandler quit.
-func (p *Peer) OutQuit() <-chan struct{} {
-	return p.outQuit
-}
-
-// Quit returns the signal chan of peer quit.
-func (p *Peer) Quit() <-chan struct{} {
-	return p.quit
 }
 
 // handleRemoteVersionMsg is invoked when a version message is received
@@ -918,13 +1056,14 @@ func (p *Peer) start() error {
 
 	// The protocol has been negotiated successfully so start processing input
 	// and output messages.
-	atomic.StoreInt32(&p.started, 1)
+	go p.stallHandler()
 	go p.inHandler()
+	go p.queueHandler()
 	go p.outHandler()
 	go p.pingHandler()
 
 	// Send our verack message now that the IO processing machinery has started.
-	p.SendMessage(msg.NewVerAck(), nil)
+	p.QueueMessage(msg.NewVerAck(), nil)
 	return nil
 }
 
@@ -977,8 +1116,12 @@ func newPeerBase(origCfg *Config, inbound bool) *Peer {
 
 	p := Peer{
 		inbound:         inbound,
-		sendQueue:       make(chan outMsg, 1), // nonblocking sync
+		stallControl:    make(chan StallControlMsg, 1), // nonblocking sync
+		outputQueue:     make(chan outMsg, outputBufferSize),
+		sendQueue:       make(chan outMsg, 1),   // nonblocking sync
+		sendDoneQueue:   make(chan struct{}, 1), // nonblocking sync
 		inQuit:          make(chan struct{}),
+		queueQuit:       make(chan struct{}),
 		outQuit:         make(chan struct{}),
 		quit:            make(chan struct{}),
 		cfg:             cfg, // Copy so caller can't mutate.

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -215,7 +215,7 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, v *msg.Version) {
 
 		// Request known addresses if the server address manager needs more.
 		if addrManager.NeedMoreAddresses() {
-			sp.SendMessage(new(msg.GetAddr), nil)
+			sp.QueueMessage(&msg.GetAddr{}, nil)
 		}
 
 		// Mark the address as a known good address.
@@ -548,7 +548,7 @@ func (s *server) handleBroadcastMsg(state *peerState, bmsg *broadcastMsg) {
 			}
 		}
 
-		go sp.SendMessage(bmsg.message, nil)
+		sp.QueueMessage(bmsg.message, nil)
 	})
 }
 


### PR DESCRIPTION
The SendMessage() method is removed because the deadlock issue.  The instead method  QueueMessage() have a 50 messages cache on start and unlimited message cache when peer started, so it can prevent deadlock issue when sending a message.