### PR TITLE
Set default value for DPoS tolerance time

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/elastos/Elastos.ELA/common"
 	"github.com/elastos/Elastos.ELA/utils/elalog"
 )
@@ -64,7 +66,7 @@ type DPoSConfiguration struct {
 	IPAddress                string         `json:"IPAddress"`
 	DPoSPort                 uint16         `json:"DPoSPort"`
 	PrintLevel               uint8          `json:"PrintLevel"`
-	SignTolerance            uint64         `json:"SignTolerance"`
+	SignTolerance            time.Duration  `json:"SignTolerance"`
 	MaxLogsSize              int64          `json:"MaxLogsSize"`
 	MaxPerLogSize            int64          `json:"MaxPerLogSize"`
 	OriginArbiters           []string       `json:"OriginArbiters"`
@@ -74,6 +76,5 @@ type DPoSConfiguration struct {
 	EmergencyInactivePenalty common.Fixed64 `json:"EmergencyInactivePenalty"`
 	MaxInactiveRounds        uint32         `json:"MaxInactiveRounds"`
 	InactivePenalty          common.Fixed64 `json:"InactivePenalty"`
-	EnableEventRecord        bool           `json:"EnableEventRecord"`
 	PreConnectOffset         uint32         `json:"PreConnectOffset"`
 }

--- a/common/config/params.go
+++ b/common/config/params.go
@@ -121,6 +121,7 @@ var DefaultParams = Params{
 	VoteStartHeight:          290000,
 	CRCOnlyDPOSHeight:        343400,
 	PublicDPOSHeight:         1108812, //fixme edit height later
+	ToleranceDuration:        5 * time.Second,
 	MaxInactiveRounds:        720 * 2,
 	InactivePenalty:          0, //there will be no penalty in this version
 	EmergencyInactivePenalty: 0, //there will be no penalty in this version
@@ -335,6 +336,9 @@ type Params struct {
 
 	// CandidateArbiters defines the number of needed candidate arbiters.
 	CandidateArbiters int
+
+	// ToleranceDuration defines the tolerance duration of the DPoS consensus.
+	ToleranceDuration time.Duration
 
 	// MaxInactiveRounds defines the maximum inactive rounds before producer
 	// takes penalty.

--- a/config.json.sample
+++ b/config.json.sample
@@ -58,8 +58,6 @@
       "EmergencyInactivePenalty": 0,
       "MaxInactiveRounds": 1440,
       "InactivePenalty": 0,
-      "InactiveEliminateCount": 12,
-      "EnableEventRecord": false,
       "PreConnectOffset": 360
     },
     "CheckAddressHeight": 88812,

--- a/docs/config.json.md
+++ b/docs/config.json.md
@@ -84,7 +84,6 @@ Default config for `testnet`
       "EmergencyInactivePenalty": 50000000000,  // EmergencyInactivePenalty defines the penalty amount the emergency producer takes.
       "MaxInactiveRounds": 1440,                // MaxInactiveRounds defines the maximum inactive rounds before producer takes penalty.
       "InactivePenalty": 10000000000,           // InactivePenalty defines the penalty amount the producer takes.
-      "InactiveEliminateCount": 12,             // InactiveEliminateCount defines arbitrators count should be eliminated
       "PreConnectOffset": 360                   // PreConnectOffset defines the offset blocks to pre-connect to the block producers.
     },
     "CheckAddressHeight": 88812,   //Before the height will not check that if address is ela address

--- a/dpos/arbitrator.go
+++ b/dpos/arbitrator.go
@@ -25,7 +25,6 @@ import (
 type Config struct {
 	EnableEventLog    bool
 	EnableEventRecord bool
-	Params            *config.DPoSConfiguration
 	Arbitrators       state.Arbitrators
 	Store             store.IDposStore
 	Server            elanet.Server
@@ -141,9 +140,6 @@ func (a *Arbitrator) OnCipherAddr(pid peer.PID, cipher []byte) {
 }
 
 func NewArbitrator(account account.Account, cfg Config) (*Arbitrator, error) {
-	log.Init(cfg.Params.PrintLevel, cfg.Params.MaxPerLogSize,
-		cfg.Params.MaxLogsSize)
-
 	medianTime := dtime.NewMedianTime()
 	dposManager := manager.NewManager(manager.DPOSManagerConfig{
 		PublicKey:   account.PublicKeyBytes(),
@@ -180,7 +176,7 @@ func NewArbitrator(account account.Account, cfg Config) (*Arbitrator, error) {
 		TimeSource:  medianTime,
 	})
 
-	consensus := manager.NewConsensus(dposManager, time.Duration(cfg.Params.SignTolerance)*time.Second, dposHandlerSwitch)
+	consensus := manager.NewConsensus(dposManager, cfg.ChainParams.ToleranceDuration, dposHandlerSwitch)
 	proposalDispatcher, illegalMonitor := manager.NewDispatcherAndIllegalMonitor(
 		manager.ProposalDispatcherConfig{
 			EventMonitor: eventMonitor,

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elastos/Elastos.ELA/core/types"
 	"github.com/elastos/Elastos.ELA/dpos"
 	"github.com/elastos/Elastos.ELA/dpos/account"
+	dlog "github.com/elastos/Elastos.ELA/dpos/log"
 	"github.com/elastos/Elastos.ELA/dpos/state"
 	"github.com/elastos/Elastos.ELA/dpos/store"
 	"github.com/elastos/Elastos.ELA/elanet"
@@ -140,10 +141,11 @@ func main() {
 
 	var arbitrator *dpos.Arbitrator
 	if act != nil {
+		dcfg := cfg.DPoSConfiguration
+		dlog.Init(dcfg.PrintLevel, dcfg.MaxPerLogSize, dcfg.MaxLogsSize)
 		arbitrator, err = dpos.NewArbitrator(act, dpos.Config{
 			EnableEventLog:    true,
 			EnableEventRecord: false,
-			Params:            &cfg.DPoSConfiguration,
 			ChainParams:       activeNetParams,
 			Arbitrators:       arbiters,
 			Store:             dposStore,


### PR DESCRIPTION
The DPoS tolerance default value is missing, it will cause producer node panic when DPoS consensus starts.