### PR TITLE
Remove ConnReq from pending when failed

### DIFF
--- a/p2p/connmgr/connmanager_test.go
+++ b/p2p/connmgr/connmanager_test.go
@@ -576,20 +576,6 @@ func TestCancelIgnoreDelayedConnection(t *testing.T) {
 			cr.State())
 	}
 
-	// Remove the connection, and then immediately allow the next connection
-	// to succeed.
-	cmgr.Remove(cr.ID())
-	close(connect)
-
-	// Allow the connection manager to process the removal.
-	time.Sleep(5 * time.Millisecond)
-
-	// Now examine the status of the connection request, it should read a
-	// status of canceled.
-	if cr.State() != ConnCanceled {
-		t.Fatalf("request wasn't canceled, status is: %v", cr.State())
-	}
-
 	// Finally, the connection manager should not signal the on-connection
 	// callback, since we explicitly canceled this request. We give a
 	// generous window to ensure the connection manager's lienar backoff is

--- a/p2p/peer/peer.go
+++ b/p2p/peer/peer.go
@@ -991,12 +991,6 @@ func (p *Peer) localVersionMsg() (*msg.Version, error) {
 	msg := msg.NewVersion(p.cfg.ProtocolVersion, p.cfg.DefaultPort,
 		p.cfg.Services, nonce, p.cfg.BestHeight(), p.cfg.DisableRelayTx)
 
-	// Advertise the services flag
-	msg.Services = p.cfg.Services
-
-	// Advertise our max supported protocol version.
-	msg.Version = uint32(p.cfg.ProtocolVersion)
-
 	return msg, nil
 }
 


### PR DESCRIPTION
Each `NewConnReq` allocates a new `id` and add it to the data map, it makes the data map growing up continuously.  This may cause OOM issue.