### PR TITLE
Remove GetBestBlock() parameter from Arbitrators

### DIFF
--- a/blockchain/txvalidator_test.go
+++ b/blockchain/txvalidator_test.go
@@ -53,10 +53,13 @@ func (s *txValidatorTestSuite) SetupSuite() {
 	s.OriginalLedger = DefaultLedger
 
 	arbiters, err := state.NewArbitrators(params, nil,
-		chainStore.GetHeight, func() (*types.Block, error) {
-			hash := chainStore.GetCurrentBlockHash()
+		chainStore.GetHeight, func(height uint32) (*types.Block, error) {
+			hash, err := chainStore.GetBlockHash(height)
+			if err != nil {
+				return nil, err
+			}
 			return chainStore.GetBlock(hash)
-		}, nil)
+		})
 	if err != nil {
 		s.Fail("initialize arbitrator failed")
 	}

--- a/cmd/script/api/api.go
+++ b/cmd/script/api/api.go
@@ -178,11 +178,7 @@ func initLedger(L *lua.LState) int {
 	}
 
 	arbiters, err := state.NewArbitrators(chainParams, dposStore,
-		chainStore.GetHeight,
-		func() (block *types.Block, e error) {
-			hash := chainStore.GetCurrentBlockHash()
-			return chainStore.GetBlock(hash)
-		}, func(height uint32) (*types.Block, error) {
+		chainStore.GetHeight, func(height uint32) (*types.Block, error) {
 			hash, err := chainStore.GetBlockHash(height)
 			if err != nil {
 				return nil, err

--- a/dpos/state/arbitrators.go
+++ b/dpos/state/arbitrators.go
@@ -57,7 +57,6 @@ type arbitrators struct {
 	store            IArbitratorsRecord
 	chainParams      *config.Params
 	bestHeight       func() uint32
-	bestBlock        func() (*types.Block, error)
 	getBlockByHeight func(uint32) (*types.Block, error)
 
 	mtx               sync.Mutex
@@ -218,7 +217,7 @@ func (a *arbitrators) ForceChange(height uint32) error {
 
 	block, err := a.getBlockByHeight(height)
 	if err != nil {
-		block, err = a.bestBlock()
+		block, err = a.getBlockByHeight(a.bestHeight())
 		if err != nil {
 			return err
 		}
@@ -913,7 +912,7 @@ func (a *arbitrators) getBlockDPOSReward(block *types.Block) common.Fixed64 {
 		totalTxFx += tx.Fee
 	}
 
-	return common.Fixed64(math.Ceil(float64(totalTxFx +
+	return common.Fixed64(math.Ceil(float64(totalTxFx+
 		a.chainParams.RewardPerBlock) * 0.35))
 }
 
@@ -1034,7 +1033,6 @@ func getArbitersInfoWithoutOnduty(title string, arbiters [][]byte) (string, []in
 func NewArbitrators(chainParams *config.Params,
 	store IArbitratorsRecord,
 	bestHeight func() uint32,
-	bestBlock func() (*types.Block, error),
 	getBlockByHeight func(uint32) (*types.Block, error)) (*arbitrators, error) {
 
 	originArbiters := make([][]byte, len(chainParams.OriginArbiters))
@@ -1080,7 +1078,6 @@ func NewArbitrators(chainParams *config.Params,
 		chainParams:                 chainParams,
 		store:                       store,
 		bestHeight:                  bestHeight,
-		bestBlock:                   bestBlock,
 		getBlockByHeight:            getBlockByHeight,
 		nextArbitrators:             originArbiters,
 		nextCandidates:              make([][]byte, 0),

--- a/dpos/state/arbitrators_test.go
+++ b/dpos/state/arbitrators_test.go
@@ -13,7 +13,7 @@ import (
 func TestArbitrators_GetSnapshot(t *testing.T) {
 	var bestHeight uint32
 	arbitrators, _ := NewArbitrators(&config.DefaultParams, nil,
-		func() uint32 { return bestHeight }, nil, nil)
+		func() uint32 { return bestHeight }, nil)
 
 	// define three height versions:
 	// firstSnapshotHeight < secondSnapshotHeight < bestHeight

--- a/dpos/state/heightversion_test.go
+++ b/dpos/state/heightversion_test.go
@@ -42,7 +42,7 @@ func TestHeightVersionInit(t *testing.T) {
 	var err error
 	bestHeight = 0
 	arbiters, err = NewArbitrators(activeNetParams, nil,
-		func() uint32 { return bestHeight }, nil, nil)
+		func() uint32 { return bestHeight }, nil)
 	assert.NoError(t, err)
 	arbiters.State = NewState(activeNetParams, nil)
 

--- a/main.go
+++ b/main.go
@@ -161,10 +161,7 @@ func startNode(c *cli.Context) {
 	blockchain.DefaultLedger = &ledger // fixme
 
 	arbiters, err := state.NewArbitrators(activeNetParams, nil,
-		chainStore.GetHeight, func() (*types.Block, error) {
-			hash := chainStore.GetCurrentBlockHash()
-			return chainStore.GetBlock(hash)
-		}, func(height uint32) (*types.Block, error) {
+		chainStore.GetHeight, func(height uint32) (*types.Block, error) {
 			hash, err := chainStore.GetBlockHash(height)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
For the Arbitrators have BestHeight() and GetBlockByHeight() method, and BestHeight()+GetBlockByHeight()=GetBestBlock(), so GetBestBlock() is a duplicate method and can be removed.