### PR TITLE
update testnet config to have testnet magic

### DIFF
--- a/docs/testnet_config.json.sample
+++ b/docs/testnet_config.json.sample
@@ -1,6 +1,7 @@
 {
   "Configuration": {
     "ActiveNet": "testnet",
+    "Magic":2018111,
     "PowConfiguration": {
       "PayToAddr": "8ZNizBf4KhhPjeJRGpox6rPcHE5Np6tFx3",
       "MinerInfo": "ELA",


### PR DESCRIPTION
Update testnet config to have testnet magic, as my node stops at block height 339121 if the magic isn't there.
The magic makes it happen.