### PR TITLE
Support batches requests

### DIFF
--- a/servers/httpjsonrpc/server.go
+++ b/servers/httpjsonrpc/server.go
@@ -134,8 +134,8 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
-	if contentType != "application/json" {
-		RPCError(w, http.StatusUnsupportedMediaType, InternalError, "JSON-RPC need content type to be application/json")
+	if contentType != "application/json" && contentType != "text/plain" {
+		RPCError(w, http.StatusUnsupportedMediaType, InternalError, "JSON-RPC need content type to be application/json or text/plain")
 		return
 	}
 

--- a/servers/httpjsonrpc/server.go
+++ b/servers/httpjsonrpc/server.go
@@ -153,64 +153,34 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	request := make(map[string]interface{})
+	var requestArray []Request
+	var request Request
+
 	err = json.Unmarshal(body, &request)
 	if err != nil {
-		log.Error("JSON-RPC request parsing error: ", err)
-		RPCError(w, http.StatusBadRequest, ParseError, "JSON-RPC request parsing error:"+err.Error())
-		return
-	}
-	//get the corresponding function
-	requestMethod, ok := request["method"].(string)
-	if !ok {
-		RPCError(w, http.StatusBadRequest, InvalidRequest, "JSON-RPC need a method")
-		return
-	}
-	method, ok := mainMux[requestMethod]
-	if !ok {
-		RPCError(w, http.StatusNotFound, MethodNotFound, "JSON-RPC method "+requestMethod+" not found")
-		return
-	}
+		log.Info("JSON-RPC request parsing error: ", err, "Try to unmarshal batches requests")
 
-	requestParams := request["params"]
-	// Json rpc 1.0 support positional parameters while json rpc 2.0 support named parameters.
-	// positional parameters: { "requestParams":[1, 2, 3....] }
-	// named parameters: { "requestParams":{ "a":1, "b":2, "c":3 } }
-	// Here we support both of them.
-	var params Params
-	switch requestParams := requestParams.(type) {
-	case nil:
-	case []interface{}:
-		params = convertParams(requestMethod, requestParams)
-	case map[string]interface{}:
-		params = Params(requestParams)
-	default:
-		RPCError(w, http.StatusBadRequest, InvalidRequest, "params format error, must be an array or a map")
-		return
+		errArray := json.Unmarshal(body, &requestArray)
+		if errArray != nil {
+			log.Error("JSON-RPC request parsing error: ", errArray)
+			RPCError(w, http.StatusBadRequest, ParseError, "JSON-RPC request parsing error:"+err.Error())
+			return
+		}
 	}
-	log.Debug("RPC method:", requestMethod)
-
-	response := method(params)
 	var data []byte
-	if response["Error"] != elaErr.ServerErrCode(0) {
-		data, _ = json.Marshal(map[string]interface{}{
-			"jsonrpc": "2.0",
-			"result":  nil,
-			"error": map[string]interface{}{
-				"code":    response["Error"],
-				"message": response["Result"],
-				"id":      request["id"],
-			},
-		})
-
+	if len(requestArray) == 0 {
+		response := getResponse(request)
+		data, _ = json.Marshal(response)
 	} else {
-		data, _ = json.Marshal(map[string]interface{}{
-			"jsonrpc": "2.0",
-			"result":  response["Result"],
-			"id":      request["id"],
-			"error":   nil,
-		})
+		var responseArray []Response
+		for _, req := range requestArray {
+			response := getResponse(req)
+			responseArray = append(responseArray, response)
+		}
+
+		data, _ = json.Marshal(responseArray)
 	}
+
 	w.Header().Set("Content-type", "application/json")
 	w.Write(data)
 }
@@ -286,6 +256,87 @@ func RPCError(w http.ResponseWriter, httpStatus int, code elaErr.ServerErrCode, 
 	w.Header().Set("Content-type", "application/json")
 	w.WriteHeader(httpStatus)
 	w.Write(data)
+}
+
+func getResponse(request Request) Response {
+	var resp Response
+	requestMethod := request.Method
+	if len(requestMethod) == 0 {
+		resp = Response{
+			JSONRPC: "2.0",
+			Result:  nil,
+			ID:      request.ID,
+			Error: map[string]interface{}{
+				"id":      request.ID,
+				"code":    InvalidRequest,
+				"message": "JSON-RPC need a method",
+			},
+		}
+		return resp
+	}
+	method, ok := mainMux[requestMethod]
+	if !ok {
+		resp = Response{
+			JSONRPC: "2.0",
+			Result:  nil,
+			ID:      request.ID,
+			Error: map[string]interface{}{
+				"id":      request.ID,
+				"code":    MethodNotFound,
+				"message": "JSON-RPC method " + requestMethod + " not found",
+			},
+		}
+		return resp
+	}
+
+	requestParams := request.Params
+	// Json rpc 1.0 support positional parameters while json rpc 2.0 support named parameters.
+	// positional parameters: { "requestParams":[1, 2, 3....] }
+	// named parameters: { "requestParams":{ "a":1, "b":2, "c":3 } }
+	// Here we support both of them.
+	var params Params
+	switch requestParams := requestParams.(type) {
+	case nil:
+	case []interface{}:
+		params = convertParams(requestMethod, requestParams)
+	case map[string]interface{}:
+		params = Params(requestParams)
+	default:
+		resp = Response{
+			JSONRPC: "2.0",
+			Result:  nil,
+			ID:      request.ID,
+			Error: map[string]interface{}{
+				"id":      request.ID,
+				"code":    InvalidRequest,
+				"message": "params format error, must be an array or a map",
+			},
+		}
+		return resp
+	}
+	log.Debug("RPC method:", requestMethod)
+
+	response := method(params)
+	if response["Error"] != elaErr.ServerErrCode(0) {
+		resp = Response{
+			JSONRPC: "2.0",
+			Result:  nil,
+			ID:      request.ID,
+			Error: map[string]interface{}{
+				"id":      request.ID,
+				"code":    response["Error"],
+				"message": response["Result"],
+			},
+		}
+	} else {
+		resp = Response{
+			JSONRPC: "2.0",
+			Result:  response["Result"],
+			ID:      request.ID,
+			Error:   nil,
+		}
+	}
+	return resp
 }
 
 func convertParams(method string, params []interface{}) Params {

--- a/servers/params.go
+++ b/servers/params.go
@@ -13,6 +13,19 @@ import (
 
 type Params map[string]interface{}
 
+type Request struct {
+	Method string      `json:"method"`
+	ID     interface{} `json:"id"`
+	Params interface{} `json:"params"`
+}
+
+type Response struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Result  interface{} `json:"result"`
+	ID      interface{} `json:"id"`
+	Error   interface{} `json:"error"`
+}
+
 func FromArray(array []interface{}, fields ...string) Params {
 	params := make(Params)
 	for i := 0; i < len(array); i++ {


### PR DESCRIPTION
Support JSON-RPC 2.0 batches, to encapsulate multiple JSON-RPC requests within a single HTTP request.