### PR TITLE
fix(dpos2.0): The ip address information of Arbiter Peers Info is displayed based on the configuration

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -93,6 +93,7 @@ type Configuration struct {
 	SchnorrStartHeight              uint32            `json:"SchnorrStartHeight"`
 	CrossChainMonitorStartHeight    uint32            `json:"CrossChainMonitorStartHeight"`
 	CrossChainMonitorInterval       uint32            `json:"CrossChainMonitorInterval"`
+	ShowPeersIp                     bool              `json:"ShowPeersIp"`
 }
 
 // DPoSConfiguration defines the DPoS consensus parameters.

--- a/servers/interfaces.go
+++ b/servers/interfaces.go
@@ -441,17 +441,20 @@ func GetArbiterPeersInfo(params Params) map[string]interface{} {
 	type peerInfo struct {
 		OwnerPublicKey string `json:"ownerpublickey"`
 		NodePublicKey  string `json:"nodepublickey"`
-		IP             string `json:"ip"`
+		IP             string `json:"ip,omitempty"`
 		ConnState      string `json:"connstate"`
 	}
 
 	peers := Arbiter.GetArbiterPeersInfo()
-
+	ip := config.Parameters.ShowPeersIp
 	result := make([]peerInfo, 0)
 	for _, p := range peers {
 		producer := Arbiters.GetConnectedProducer(p.PID[:])
 		if producer == nil {
 			continue
+		}
+		if !ip {
+			p.Addr = ""
 		}
 		result = append(result, peerInfo{
 			OwnerPublicKey: common.BytesToHexString(


### PR DESCRIPTION
The ip address information of Arbiter Peers Info is displayed based on the configuration

Signed-off-by: xiaobo <peterwillcn@gmail.com
![Screen Shot 2022-06-15 at 11 26 09](https://user-images.githubusercontent.com/323794/173730574-13ac5e11-543b-49fb-9f38-70584b5c82b6.png)
![Screen Shot 2022-06-15 at 11 23 02](https://user-images.githubusercontent.com/323794/173730579-d80aba9d-24b4-4bc1-8494-7d80354c1e30.png)
>