### PR TITLE
Typos fix

### DIFF
--- a/docs/cli_user_guide.md
+++ b/docs/cli_user_guide.md
@@ -878,7 +878,7 @@ File:  to_be_signed.txn
   ```
 
   - step 4: crcouncil member sign the digest of payload
-  - step 5: create chage custom id fee proposal transaction
+  - step 5: create change, charge custom id fee proposal transaction
 
   ```shell
   $ ./ela-cli wallet buildtx proposal changecustomidfee -w temp.dat --fee 0.0001 --payload 0205043132333421024b89fe23a982325126058cea21374bc6599ebe38fd950a8f9bf2804f2bfc98423bb9c593ed65b2fe2fea729588d5d8dced2d474a885b75fcb8a52ced366745a10312345610270000000000004e61bc0040a872e9313fabd7a0cbd16ba74394390050abfaadadf6a28d24d972a1cadda90097f39d2bd82b2d6db9800dfae3e38f61dc6a4f4fdfd2a3e7e2b100fc11ce628b677278335e5528c304acda6fb59d612c340cc17022 --crcmembersignature cc7f0b3dd78718635698bbe0e4676245795a80f177bc43c78e30ddb7552074f36348a8e4ad5824c7b565649849e9af5ca59305c361537924b353c8170c3f6bec

--- a/docs/jsonrpc_apis.md
+++ b/docs/jsonrpc_apis.md
@@ -285,7 +285,7 @@ Response:
 
 ### getrawtransaction
 
-Get transaction infomation of given transaction hash.
+Get transaction information of given transaction hash.
 
 #### Parameter 
 
@@ -322,7 +322,7 @@ Request:
 }
 ```
 
-Response when verbosity is ture:
+Response when verbosity is true, pure:
 
 ```json
 {
@@ -444,7 +444,7 @@ Response:
                 "blockheight": 366174,
                 "sideblockhash": "50e95c5452808282249827971def9b6d01a83a62251aada221b20ea66755f44b",
                 "sidegenesishash": "a3c455a90843db2acd22554f2768a8d4233fafbf8dd549e6b261c2786993be56",
-                "signature": "fdcb69746140a2c9b42c91642e5f887c7859c3709c189a83ed09ac2305d524d66e3b77dff3e9c070323d312afb8efedc60ce41c12e6684e0db5088bad1683a92"
+                "signatrue, pure": "fdcb69746140a2c9b42c91642e5f887c7859c3709c189a83ed09ac2305d524d66e3b77dff3e9c070323d312afb8efedc60ce41c12e6684e0db5088bad1683a92"
             },
             "attributes": [
                 {
@@ -1019,7 +1019,7 @@ warning: this interface is ready to be deprecated. So no api information will be
 
 ### listproducers
 
-Show producers infromation
+Show producers information
 
 #### Parameter 
 
@@ -1983,19 +1983,19 @@ if state flag not provided return the cr candidates in pending and active state.
 #### Result
 | name           | type   | description                               |
 | -------------- | ------ | ----------------------------------------- |
-| code           | string | the cr candiate code                      |
-| cid            | string | the cr candiate address                   |
-| did            | string | the cr candiate did address               |
-| nickname       | string | the nick name of the cr candiate          |
-| url            | string | the url of the cr candiate                |
-| location       | uint64 | the location number of the cr candiate    |
-| state          | bool   | if cr candiate has confirmed              |
+| code           | string | the cr candidate code                      |
+| cid            | string | the cr candidate address                   |
+| did            | string | the cr candidate did address               |
+| nickname       | string | the nick name of the cr candidate          |
+| url            | string | the url of the cr candidate                |
+| location       | uint64 | the location number of the cr candidate    |
+| state          | bool   | if cr candidate has confirmed              |
 | votes          | string | the votes currently held                  |
 | registerheight | uint32 | the register CR candidate height          |
 | cancelheight   | uint32 | the unregister CR candidate height        |
-| index          | uint64 | the index of the cr candiate              |
-| totalvotes     | string | the total votes of registered cr candiate |
-| totalcounts    | uint64 | the total counts of registered cr candiate|
+| index          | uint64 | the index of the cr candidate              |
+| totalvotes     | string | the total votes of registered cr candidate |
+| totalcounts    | uint64 | the total counts of registered cr candidate|
 
 #### Example
 
@@ -2082,7 +2082,7 @@ Show current cr members information
 | url             | string | the url of the cr member                  |
 | location        | uint64 | the location number of the cr member      |
 | impeachmentvotes| int64  | impeachment votes of the cr member        |
-| depositamount   | string | the deposite amout of the cr member       |
+| depositamount   | string | the deposite amount of the cr member       |
 | depositaddress  | string | the deposite address of the cr member     |
 | penalty         | int64  | the penalty of the cr member              |
 | index           | uint64 | the index of the cr member                |
@@ -2116,7 +2116,7 @@ Response:
                 "nickname": "ela_cr2",
                 "url": "ela_cr2.org",
                 "location": 112211, "impeachmentvotes": 0,
-                "depositamout": "5000",
+                "depositamount": "5000",
                 "deposithash": "De87Qiekzpx7Xqf8RphdwNX5Z84iGgHLKMF5b",
                 "penalty": 0,
                 "index": 0,
@@ -2130,7 +2130,7 @@ Response:
                 "url": "ela_cr1.org",
                 "location": 112211,
                 "impeachmentvotes": 0,
-                "depositamout": "5000",
+                "depositamount": "5000",
                 "depositaddress": "DnemZpPgHLKMF5bMX3WbJYSGTpqJkBN7pe",
                 "penalty": 0,
                 "index": 1,
@@ -2168,7 +2168,7 @@ Show current cr proposal base state information
 | ------------------ | --------------------- | -------------------------------------------------- |
 | status             | string                | the proposal status                                |
 | proposalhash       | string                | the cr proposal hash                               |
-| txhash             | string                | the transacion's hash which cr proposal located in |
+| txhash             | string                | the transaction's hash which cr proposal located in |
 | crvotes            | map[string]VoteResult | per cr VoteResult                                  |
 | votersrejectamount | common.Fixed64        | voters reject amount                               |
 | registerheight     | uint32                | register height of proposal                        |
@@ -2243,7 +2243,7 @@ Get one cr proposal detail state information by proposalhash or drafthash
 | ------------------ | --------------------- | -------------------------------------------------- |
 | Status             | string                | the proposal status                                |
 | Proposal           | CRCProposal           | the cr proposal                                    |
-| TxHash             | string                | hash of the transacion which cr proposal located in|
+| TxHash             | string                | hash of the transaction which cr proposal located in|
 | CRVotes            | map[string]VoteResult | per cr VoteResult                                  |
 | VotersRejectAmount | string                | voters reject amount                               |
 | RegisterHeight     | uint32                | the proposal register height                       |
@@ -2427,7 +2427,7 @@ Response:
 | -------- | ------------- | ---------------------------------- |
 | inputs   | array[string] | inputs json array of json objects  |
 | outputs  | array[string] | outputs json array of json objects |
-| locktime | interger      | the transaction lock time number   |
+| locktime | integer      | the transaction lock time number   |
 
  #### Example
 


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /docs/jsonrpc_apis.md (Line 288)

"infomation" → "information"

Corrected typo in /docs/jsonrpc_apis.md (Line 325)

"ture" → "true, pure"

Corrected typo in /docs/jsonrpc_apis.md (Line 1022)

"infromation" → "information"

Corrected typo in /docs/jsonrpc_apis.md (Line 1986)

"candiate" → "candidate"

Corrected typo in /docs/jsonrpc_apis.md (Line 1987)

"candiate" → "candidate"

Corrected typo in /docs/jsonrpc_apis.md (Line 1988)

"candiate" → "candidate"

Corrected typo in /docs/jsonrpc_apis.md (Line 2085)

"amout" → "amount"

Corrected typo in /docs/jsonrpc_apis.md (Line 2246)

"transacion" → "transaction"

Corrected typo in /docs/jsonrpc_apis.md (Line 2430)

"interger" → "integer"

Corrected typo in /docs/cli_user_guide.md (Line 881)

"chage" → "change, charge"

**Purpose**

Improved code accuracy and professionalism by fixing typos.